### PR TITLE
Reuse pooled objects for collectibles

### DIFF
--- a/Assets/Scripts/Coin.cs
+++ b/Assets/Scripts/Coin.cs
@@ -17,7 +17,15 @@ public class Coin : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
-            Destroy(gameObject);
+            PooledObject po = GetComponent<PooledObject>();
+            if (po != null && po.Pool != null)
+            {
+                po.Pool.ReturnObject(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
         }
     }
 }

--- a/Assets/Scripts/MagnetPowerUp.cs
+++ b/Assets/Scripts/MagnetPowerUp.cs
@@ -18,7 +18,15 @@ public class MagnetPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
-            Destroy(gameObject);
+            PooledObject po = GetComponent<PooledObject>();
+            if (po != null && po.Pool != null)
+            {
+                po.Pool.ReturnObject(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
         }
     }
 }

--- a/Assets/Scripts/SpeedBoostPowerUp.cs
+++ b/Assets/Scripts/SpeedBoostPowerUp.cs
@@ -19,7 +19,15 @@ public class SpeedBoostPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
-            Destroy(gameObject);
+            PooledObject po = GetComponent<PooledObject>();
+            if (po != null && po.Pool != null)
+            {
+                po.Pool.ReturnObject(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- use object pooling when coins and power-ups are collected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fac74c4ac83219947575055b45e49