### PR TITLE
Use NonAlloc for coin magnet

### DIFF
--- a/Assets/Scripts/CoinMagnet.cs
+++ b/Assets/Scripts/CoinMagnet.cs
@@ -6,9 +6,19 @@ public class CoinMagnet : MonoBehaviour
     public float magnetSpeed = 10f;
     // Layer mask so only coins are searched when attracting them.
     public LayerMask coinLayer;
+    // How many colliders can be detected each frame.
+    [SerializeField]
+    private int colliderBufferSize = 10;
+    // Preallocated buffer to store detected colliders.
+    private Collider2D[] _colliderBuffer;
 
     private float magnetTimer;
     private bool magnetActive;
+
+    void Awake()
+    {
+        _colliderBuffer = new Collider2D[colliderBufferSize];
+    }
 
     void Update()
     {
@@ -29,10 +39,11 @@ public class CoinMagnet : MonoBehaviour
     void AttractCoins()
     {
         // Only check colliders on the specified coin layer for better performance.
-        Collider2D[] coins = Physics2D.OverlapCircleAll(transform.position, magnetRadius, coinLayer);
-        foreach (Collider2D c in coins)
+        int count = Physics2D.OverlapCircleNonAlloc(transform.position, magnetRadius, _colliderBuffer, coinLayer);
+        for (int i = 0; i < count; i++)
         {
-            if (c.CompareTag("Coin"))
+            Collider2D c = _colliderBuffer[i];
+            if (c != null && c.CompareTag("Coin"))
             {
                 c.transform.position = Vector3.MoveTowards(c.transform.position, transform.position, magnetSpeed * Time.deltaTime);
             }


### PR DESCRIPTION
## Summary
- add collider buffer to reuse allocations
- swap `OverlapCircleAll` with `OverlapCircleNonAlloc`
- iterate using returned count to move attracted coins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841190c550083218c8aad5a1e052d4f