### PR TITLE
Fix object pool initialization and add tests

### DIFF
--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -9,7 +9,9 @@ public class ObjectPool : MonoBehaviour
 
     private Queue<PooledObject> objects = new Queue<PooledObject>();
 
-    void Awake()
+    // Delay initialization until Start so prefab can be assigned by spawners
+    // before the pool creates its initial objects.
+    void Start()
     {
         if (prefab == null) return;
         for (int i = 0; i < initialSize; i++)

--- a/Assets/Tests/EditMode/CoinTests.cs
+++ b/Assets/Tests/EditMode/CoinTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class CoinTests
+{
+    [Test]
+    public void CollectingCoinAddsCoinsAndReturnsToPool()
+    {
+        // Set up GameManager instance
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+
+        // Set up pool and coin
+        var poolObj = new GameObject("pool");
+        var pool = poolObj.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+
+        var coinObj = new GameObject("coin");
+        var coin = coinObj.AddComponent<Coin>();
+        var pooled = coinObj.AddComponent<PooledObject>();
+        pooled.Pool = pool;
+        var coinCollider = coinObj.AddComponent<BoxCollider2D>();
+        coinCollider.isTrigger = true;
+
+        // Create player collider
+        var playerObj = new GameObject("player");
+        playerObj.tag = "Player";
+        var playerCollider = playerObj.AddComponent<BoxCollider2D>();
+
+        coin.OnTriggerEnter2D(playerCollider);
+
+        Assert.AreEqual(coin.value, gm.GetCoins());
+        Assert.IsFalse(coinObj.activeSelf);
+
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(playerObj);
+        Object.DestroyImmediate(coinObj);
+        Object.DestroyImmediate(poolObj);
+        Object.DestroyImmediate(gmObj);
+    }
+
+    [Test]
+    public void GameOverUpdatesHighScore()
+    {
+        PlayerPrefs.SetInt("HighScore", 5);
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+
+        // Set internal distance via reflection
+        var field = typeof(GameManager).GetField("distance", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field.SetValue(gm, 10f);
+
+        gm.GameOver();
+
+        Assert.AreEqual(10, PlayerPrefs.GetInt("HighScore"));
+        Object.DestroyImmediate(gmObj);
+    }
+}


### PR DESCRIPTION
## Summary
- initialize ObjectPool in `Start` so spawners assign prefabs first
- add tests covering coin collection and high score updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411f974d7883219c8974b606386791