### PR TITLE
Ensure callback on zero subscribed items

### DIFF
--- a/Assets/Scripts/WorkshopManager.cs
+++ b/Assets/Scripts/WorkshopManager.cs
@@ -55,6 +55,12 @@ public class WorkshopManager : MonoBehaviour
         }
 
         uint count = SteamUGC.GetNumSubscribedItems();
+        if (count == 0)
+        {
+            callback?.Invoke(new List<string>());
+            return;
+        }
+
         PublishedFileId_t[] ids = new PublishedFileId_t[count];
         SteamUGC.GetSubscribedItems(ids, count);
 


### PR DESCRIPTION
## Summary
- call `DownloadSubscribedItems` callback when `SteamUGC.GetNumSubscribedItems()` returns 0

## Testing
- `npm test`