### PR TITLE
Fix MovingPlatform motion timer

### DIFF
--- a/Assets/Scripts/MovingPlatform.cs
+++ b/Assets/Scripts/MovingPlatform.cs
@@ -21,6 +21,13 @@ public class MovingPlatform : MonoBehaviour
     private Vector3 startPos;
 
     /// <summary>
+    /// Internal timer used to drive the sine wave motion. Incremented
+    /// using <see cref="Time.deltaTime"/> so it halts when
+    /// <c>Time.timeScale</c> is zero.
+    /// </summary>
+    private float timer;
+
+    /// <summary>
     /// Stores the starting position to calculate the oscillation offset.
     /// </summary>
     void Start()
@@ -29,11 +36,23 @@ public class MovingPlatform : MonoBehaviour
     }
 
     /// <summary>
+    /// Called whenever the object becomes enabled. Resets the starting
+    /// position and timer so pooled instances start from their new
+    /// location without continuing the previous animation cycle.
+    /// </summary>
+    void OnEnable()
+    {
+        startPos = transform.position;
+        timer = 0f;
+    }
+
+    /// <summary>
     /// Oscillates the platform vertically using a sine wave.
     /// </summary>
     void Update()
     {
-        float y = Mathf.Sin(Time.time * frequency) * amplitude;
+        timer += Time.deltaTime;
+        float y = Mathf.Sin(timer * frequency) * amplitude;
         transform.position = new Vector3(transform.position.x, startPos.y + y, transform.position.z);
     }
 }

--- a/Assets/Tests/EditMode/MovingPlatformTests.cs
+++ b/Assets/Tests/EditMode/MovingPlatformTests.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests for the MovingPlatform component ensuring pooled instances reset
+/// their starting position and that movement halts when the game is paused.
+/// </summary>
+public class MovingPlatformTests
+{
+    [Test]
+    public void OnEnable_ResetsStartPositionAndTimer()
+    {
+        var go = new GameObject("platform");
+        var mp = go.AddComponent<MovingPlatform>();
+
+        // Move the object and trigger OnEnable as if it were spawned
+        go.transform.position = new Vector3(2f, 3f, 0f);
+        mp.OnEnable();
+
+        // Change position and timer then simulate returning from a pool
+        var timerField = typeof(MovingPlatform).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance);
+        timerField.SetValue(mp, 5f);
+        go.transform.position = new Vector3(5f, 6f, 0f);
+        mp.OnEnable();
+
+        var startPosField = typeof(MovingPlatform).GetField("startPos", BindingFlags.NonPublic | BindingFlags.Instance);
+        Vector3 startPos = (Vector3)startPosField.GetValue(mp);
+        float timer = (float)timerField.GetValue(mp);
+
+        Assert.AreEqual(go.transform.position, startPos);
+        Assert.AreEqual(0f, timer);
+
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void Update_HaltsWhenTimeScaleZero()
+    {
+        var go = new GameObject("platform");
+        var mp = go.AddComponent<MovingPlatform>();
+        mp.OnEnable();
+
+        // Pre-set timer to simulate elapsed time so the platform would move
+        var timerField = typeof(MovingPlatform).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance);
+        timerField.SetValue(mp, 1f);
+        mp.Update();
+        float yBeforePause = go.transform.position.y;
+
+        Time.timeScale = 0f;
+        mp.Update();
+        float yAfterPause = go.transform.position.y;
+        Time.timeScale = 1f;
+
+        Assert.AreEqual(yBeforePause, yAfterPause);
+        Object.DestroyImmediate(go);
+    }
+}


### PR DESCRIPTION
## Summary
- add timer variable and `OnEnable` to `MovingPlatform`
- halt platform movement when timeScale is zero
- add EditMode tests for pooled platforms

## Testing
- `npm test`