### PR TITLE
Add edit mode tests for power-ups and update README

### DIFF
--- a/Assets/Tests/EditMode/CoinMagnetTests.cs
+++ b/Assets/Tests/EditMode/CoinMagnetTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests for the CoinMagnet component verifying activation
+/// and deactivation logic.
+/// </summary>
+public class CoinMagnetTests
+{
+    [Test]
+    public void ActivateMagnet_SetsTimerAndActive()
+    {
+        var player = new GameObject("player");
+        var magnet = player.AddComponent<CoinMagnet>();
+        magnet.ActivateMagnet(2f);
+
+        var activeField = typeof(CoinMagnet).GetField("magnetActive", BindingFlags.NonPublic | BindingFlags.Instance);
+        var timerField = typeof(CoinMagnet).GetField("magnetTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        bool active = (bool)activeField.GetValue(magnet);
+        float timer = (float)timerField.GetValue(magnet);
+
+        Assert.IsTrue(active);
+        Assert.AreEqual(2f, timer);
+
+        Object.DestroyImmediate(player);
+    }
+
+    [Test]
+    public void Update_DisablesWhenTimerExpires()
+    {
+        var player = new GameObject("player");
+        var magnet = player.AddComponent<CoinMagnet>();
+
+        var activeField = typeof(CoinMagnet).GetField("magnetActive", BindingFlags.NonPublic | BindingFlags.Instance);
+        var timerField = typeof(CoinMagnet).GetField("magnetTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        activeField.SetValue(magnet, true);
+        timerField.SetValue(magnet, 0f);
+
+        magnet.Update();
+
+        bool active = (bool)activeField.GetValue(magnet);
+        Assert.IsFalse(active);
+
+        Object.DestroyImmediate(player);
+    }
+}

--- a/Assets/Tests/EditMode/PowerUpSpawnerTests.cs
+++ b/Assets/Tests/EditMode/PowerUpSpawnerTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests for the PowerUpSpawner component verifying pools are
+/// created and reused correctly.
+/// </summary>
+public class PowerUpSpawnerTests
+{
+    [Test]
+    public void Start_CreatesPoolsForPrefabs()
+    {
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<PowerUpSpawner>();
+        spawner.usePooling = true;
+        var prefab1 = new GameObject("prefab1");
+        var prefab2 = new GameObject("prefab2");
+        spawner.powerUpPrefabs = new[] { prefab1, prefab2 };
+
+        spawner.Start();
+
+        var poolsField = typeof(PowerUpSpawner).GetField("pools", BindingFlags.NonPublic | BindingFlags.Instance);
+        var pools = (System.Collections.Generic.Dictionary<GameObject, ObjectPool>)poolsField.GetValue(spawner);
+        Assert.AreEqual(2, pools.Count);
+
+        Object.DestroyImmediate(prefab1);
+        Object.DestroyImmediate(prefab2);
+        Object.DestroyImmediate(spawnerObj);
+    }
+
+    [Test]
+    public void SpawnPowerUp_ReusesInstanceFromPool()
+    {
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<PowerUpSpawner>();
+        spawner.usePooling = true;
+        var prefab = new GameObject("prefab");
+        spawner.powerUpPrefabs = new[] { prefab };
+        spawner.spawnInterval = 1f;
+
+        // Create pool with a single object
+        spawner.Start();
+        var poolsField = typeof(PowerUpSpawner).GetField("pools", BindingFlags.NonPublic | BindingFlags.Instance);
+        var pools = (System.Collections.Generic.Dictionary<GameObject, ObjectPool>)poolsField.GetValue(spawner);
+        var pool = pools[prefab];
+        pool.initialSize = 1;
+        pool.Start();
+
+        // Spawn a power-up then return it
+        var spawnMethod = typeof(PowerUpSpawner).GetMethod("SpawnPowerUp", BindingFlags.NonPublic | BindingFlags.Instance);
+        spawnMethod.Invoke(spawner, null);
+        var spawned = pool.transform.GetChild(0).gameObject;
+        pool.ReturnObject(spawned);
+
+        // Spawn again and ensure the same instance was reused
+        spawnMethod.Invoke(spawner, null);
+        var spawnedAgain = pool.transform.GetChild(0).gameObject;
+        Assert.AreSame(spawned, spawnedAgain);
+
+        Object.DestroyImmediate(prefab);
+        Object.DestroyImmediate(spawnerObj);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ This repository includes a small suite of EditMode tests.
 2. Select the **EditMode** tab and click **Run All** to execute the tests.
 
 The test scripts are located in `Assets/Tests/EditMode`.
+New tests exercise behaviour for components like **MovingPlatform**,
+**PowerUpSpawner**, and **CoinMagnet** to ensure pausing and pooled
+objects work correctly.
 
 ## Opening, Running, and Building in Unity 2022.3 LTS
 1. Launch **Unity Hub** and make sure **Unity 2022.3 LTS** is installed.


### PR DESCRIPTION
## Summary
- test object pooling in `PowerUpSpawner`
- test enabling/disabling logic for `CoinMagnet`
- mention new EditMode tests in documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d31128c88321a3d90f057e7a7ff3