### PR TITLE
Implement StageManager with stage-specific assets

### DIFF
--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -1,0 +1,118 @@
+// StageManager.cs
+// -----------------------------------------------------------------------------
+// Handles stage progression events triggered by the GameManager. When a stage
+// is unlocked it swaps the active background sprite and adjusts obstacle and
+// hazard prefab lists to increase difficulty.
+// -----------------------------------------------------------------------------
+
+using UnityEngine;
+
+/// <summary>
+/// Coordinates stage-related visuals and hazards as the player travels further.
+/// Attach this component to a persistent object and assign background,
+/// obstacle and hazard references in the inspector.
+/// </summary>
+public class StageManager : MonoBehaviour
+{
+    [System.Serializable]
+    public class StageData
+    {
+        [Tooltip("Sprite loaded from Resources/Art to use as the background.")]
+        public string backgroundSprite;
+
+        [Tooltip("Ground obstacles available during this stage.")]
+        public GameObject[] groundObstacles;
+        [Tooltip("Ceiling obstacles available during this stage.")]
+        public GameObject[] ceilingObstacles;
+        [Tooltip("Moving platforms spawned in this stage.")]
+        public GameObject[] movingPlatforms;
+        [Tooltip("Rotating hazards spawned in this stage.")]
+        public GameObject[] rotatingHazards;
+
+        [Tooltip("Pit hazards for the HazardSpawner.")]
+        public GameObject[] pits;
+        [Tooltip("Flying hazards such as bats for the HazardSpawner.")]
+        public GameObject[] bats;
+    }
+
+    [Tooltip("Background component whose spriteName will change per stage.")]
+    public ParallaxBackground parallaxBackground;
+    [Tooltip("Obstacle spawner to update when a new stage begins.")]
+    public ObstacleSpawner obstacleSpawner;
+    [Tooltip("Hazard spawner to update when a new stage begins.")]
+    public HazardSpawner hazardSpawner;
+
+    [Tooltip("Ordered list of data for each stage.")]
+    public StageData[] stages;
+
+    void Awake()
+    {
+        // Subscribe to stage unlock notifications from the GameManager.
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnStageUnlocked += ApplyStage;
+        }
+    }
+
+    void Start()
+    {
+        // Ensure the initial stage settings are applied at startup.
+        int initialStage = GameManager.Instance != null ? GameManager.Instance.GetCurrentStage() : 0;
+        ApplyStage(initialStage);
+    }
+
+    void OnDestroy()
+    {
+        // Unsubscribe when destroyed to avoid dangling delegates.
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnStageUnlocked -= ApplyStage;
+        }
+    }
+
+    /// <summary>
+    /// Updates background and spawner prefabs for the specified stage index.
+    /// Called when GameManager unlocks a new stage.
+    /// </summary>
+    /// <param name="stageIndex">Index of the stage to apply.</param>
+    public void ApplyStage(int stageIndex)
+    {
+        if (stages == null || stageIndex < 0 || stageIndex >= stages.Length)
+        {
+            return; // invalid index or no data
+        }
+
+        StageData data = stages[stageIndex];
+
+        // Swap the scrolling background sprite if a name was provided.
+        if (parallaxBackground != null && !string.IsNullOrEmpty(data.backgroundSprite))
+        {
+            parallaxBackground.spriteName = data.backgroundSprite;
+            var sr = parallaxBackground.GetComponent<SpriteRenderer>();
+            if (sr != null)
+            {
+                Sprite loaded = Resources.Load<Sprite>("Art/" + data.backgroundSprite);
+                if (loaded != null)
+                {
+                    sr.sprite = loaded;
+                }
+            }
+        }
+
+        // Update obstacle prefabs so newly spawned objects reflect the stage.
+        if (obstacleSpawner != null)
+        {
+            obstacleSpawner.groundObstacles = data.groundObstacles;
+            obstacleSpawner.ceilingObstacles = data.ceilingObstacles;
+            obstacleSpawner.movingPlatforms = data.movingPlatforms;
+            obstacleSpawner.rotatingHazards = data.rotatingHazards;
+        }
+
+        // Update hazard prefabs for pits and flying enemies.
+        if (hazardSpawner != null)
+        {
+            hazardSpawner.pitPrefabs = data.pits;
+            hazardSpawner.batPrefabs = data.bats;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/StageManagerTests.cs
+++ b/Assets/Tests/EditMode/StageManagerTests.cs
@@ -1,0 +1,106 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Unit tests for the StageManager component verifying stage application and
+/// event-driven updates from the GameManager.
+/// </summary>
+public class StageManagerTests
+{
+    [Test]
+    public void ApplyStage_UpdatesSpawnerLists()
+    {
+        // Setup basic objects and component hierarchy
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+
+        var bgObj = new GameObject("bg");
+        bgObj.AddComponent<SpriteRenderer>();
+        var bg = bgObj.AddComponent<ParallaxBackground>();
+
+        var obsObj = new GameObject("obs");
+        var obstacleSpawner = obsObj.AddComponent<ObstacleSpawner>();
+
+        var hazObj = new GameObject("haz");
+        var hazardSpawner = hazObj.AddComponent<HazardSpawner>();
+
+        var smObj = new GameObject("sm");
+        var sm = smObj.AddComponent<StageManager>();
+        sm.parallaxBackground = bg;
+        sm.obstacleSpawner = obstacleSpawner;
+        sm.hazardSpawner = hazardSpawner;
+
+        // Provide simple prefabs for stage data
+        var dummy = new GameObject("prefab");
+        var stage = new StageManager.StageData
+        {
+            backgroundSprite = "stageA",
+            groundObstacles = new[] { dummy },
+            ceilingObstacles = new GameObject[0],
+            movingPlatforms = new GameObject[0],
+            rotatingHazards = new GameObject[0],
+            pits = new GameObject[0],
+            bats = new GameObject[0]
+        };
+        sm.stages = new[] { stage };
+
+        sm.ApplyStage(0);
+
+        Assert.AreEqual("stageA", bg.spriteName);
+        Assert.AreSame(dummy, obstacleSpawner.groundObstacles[0]);
+
+        Object.DestroyImmediate(dummy);
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(bgObj);
+        Object.DestroyImmediate(obsObj);
+        Object.DestroyImmediate(hazObj);
+        Object.DestroyImmediate(smObj);
+    }
+
+    [Test]
+    public void Event_TriggersStageChange()
+    {
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.stageGoals = new float[] { 0.1f };
+
+        var bgObj = new GameObject("bg");
+        bgObj.AddComponent<SpriteRenderer>();
+        var bg = bgObj.AddComponent<ParallaxBackground>();
+
+        var obsObj = new GameObject("obs");
+        var obstacleSpawner = obsObj.AddComponent<ObstacleSpawner>();
+
+        var hazObj = new GameObject("haz");
+        var hazardSpawner = hazObj.AddComponent<HazardSpawner>();
+
+        var smObj = new GameObject("sm");
+        var sm = smObj.AddComponent<StageManager>();
+        sm.parallaxBackground = bg;
+        sm.obstacleSpawner = obstacleSpawner;
+        sm.hazardSpawner = hazardSpawner;
+        sm.stages = new[] {
+            new StageManager.StageData { backgroundSprite = "start" },
+            new StageManager.StageData { backgroundSprite = "next" }
+        };
+
+        gm.StartGame();
+        // Initial stage should apply index 0
+        Assert.AreEqual("start", bg.spriteName);
+
+        // Force distance over goal then call GameManager.Update via reflection
+        var distField = typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance);
+        distField.SetValue(gm, 0.2f);
+        var update = typeof(GameManager).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance);
+        update.Invoke(gm, null);
+
+        Assert.AreEqual("next", bg.spriteName);
+
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(bgObj);
+        Object.DestroyImmediate(obsObj);
+        Object.DestroyImmediate(hazObj);
+        Object.DestroyImmediate(smObj);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,16 @@ with your app's ID so Steamworks initializes correctly.
 - Attach two `AudioSource` components to a new `AudioManager` GameObject—one for music and one for sound effects—then assign them in the inspector.
 - Place `ObstacleSpawner`, `HazardSpawner`, and `CoinSpawner` objects slightly off the right side of the screen (around x = 10) so spawned prefabs scroll in from the side. The spawners automatically reuse objects with an internal pool for smoother performance.
 - Add a `PowerUpSpawner` object with magnet or speed boost prefabs so players can collect temporary power-ups. Attach a `CoinMagnet` component to the player for magnet bonuses.
+- Add a `StageManager` object and assign background sprite names and obstacle
+  prefabs for each stage. The manager listens to `GameManager.OnStageUnlocked`
+  and swaps the active background plus spawner lists when new stages begin.
 This project now includes simple menus, audio hooks, and escalating difficulty but you can further expand it with custom art, music, and polished effects.
+## Stage Configuration
+`GameManager` uses the `stageGoals` array to determine when stages unlock.
+Each element maps to an entry on `StageManager`. Provide the background sprite
+name along with obstacle and hazard prefabs for that stage so tougher hazards
+appear as players progress.
+
 
 ## Steam Integration
 The project optionally supports Steam achievements and cloud saves using the


### PR DESCRIPTION
## Summary
- add `StageManager` component to react to `GameManager.OnStageUnlocked`
- adjust obstacle and hazard spawners when a new stage begins
- swap background via `ParallaxBackground.spriteName`
- document usage and configuration in README
- cover new behaviour with unit tests

## Testing
- `npm test`