### PR TITLE
Add ShopManager and persistent upgrade system

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -245,6 +245,12 @@ public class GameManager : MonoBehaviour
             // Submit the score to the Steam leaderboard
             SteamManager.Instance.UploadScore(finalScore);
         }
+
+        // Persist run coins so they can be spent in the shop
+        if (ShopManager.Instance != null)
+        {
+            ShopManager.Instance.AddCoins(coins);
+        }
         // Update the UI with the final results
         if (uiManager != null)
         {

--- a/Assets/Scripts/MagnetPowerUp.cs
+++ b/Assets/Scripts/MagnetPowerUp.cs
@@ -20,7 +20,13 @@ public class MagnetPowerUp : MonoBehaviour
             CoinMagnet magnet = other.GetComponent<CoinMagnet>();
             if (magnet != null)
             {
-                magnet.ActivateMagnet(duration);
+                // Include any purchased upgrade so the magnet lasts longer
+                float totalDuration = duration;
+                if (ShopManager.Instance != null)
+                {
+                    totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.MagnetDuration);
+                }
+                magnet.ActivateMagnet(totalDuration);
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Scripts/ShopManager.cs
+++ b/Assets/Scripts/ShopManager.cs
@@ -1,0 +1,137 @@
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Central shop system that persists the player's coin total and purchased
+/// upgrades between sessions using PlayerPrefs. Each upgrade increases a
+/// gameplay value such as power-up duration.
+/// </summary>
+public class ShopManager : MonoBehaviour
+{
+    public static ShopManager Instance { get; private set; }
+
+    /// <summary>
+    /// Defines a purchasable upgrade entry exposed in the inspector.
+    /// </summary>
+    [Serializable]
+    public struct UpgradeData
+    {
+        public UpgradeType type;  // unique identifier for the upgrade
+        public int cost;          // cost in coins per purchase
+        public float effect;      // effect added per upgrade level
+    }
+
+    [Tooltip("Upgrades players can buy in the shop.")]
+    public UpgradeData[] availableUpgrades;
+
+    // Tracks how many times each upgrade has been purchased.
+    private readonly Dictionary<UpgradeType, int> upgradeLevels = new Dictionary<UpgradeType, int>();
+
+    private const string CoinsKey = "ShopCoins";
+    private const string UpgradePrefix = "UpgradeLevel_";
+
+    /// <summary>Current coin balance saved across sessions.</summary>
+    public int Coins { get; private set; }
+
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            LoadState();
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    /// <summary>
+    /// Adds coins to the persistent balance and saves immediately.
+    /// </summary>
+    public void AddCoins(int amount)
+    {
+        if (amount < 0)
+        {
+            throw new ArgumentException("amount must be non-negative", nameof(amount));
+        }
+        Coins += amount;
+        SaveState();
+    }
+
+    /// <summary>
+    /// Attempts to purchase an upgrade. Returns true when successful.
+    /// </summary>
+    public bool PurchaseUpgrade(UpgradeType type)
+    {
+        UpgradeData data = GetData(type);
+        if (Coins < data.cost)
+        {
+            return false; // not enough coins
+        }
+
+        Coins -= data.cost;
+        if (upgradeLevels.ContainsKey(type))
+        {
+            upgradeLevels[type]++;
+        }
+        else
+        {
+            upgradeLevels[type] = 1;
+        }
+        SaveState();
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the cumulative effect value for the provided upgrade type.
+    /// </summary>
+    public float GetUpgradeEffect(UpgradeType type)
+    {
+        UpgradeData data = GetData(type);
+        if (upgradeLevels.TryGetValue(type, out int level))
+        {
+            return data.effect * level;
+        }
+        return 0f;
+    }
+
+    // Fetches upgrade data from the configured list. If not found, returns a
+    // default struct so callers do not crash.
+    private UpgradeData GetData(UpgradeType type)
+    {
+        foreach (var up in availableUpgrades)
+        {
+            if (up.type == type)
+            {
+                return up;
+            }
+        }
+        Debug.LogWarning("Upgrade not configured: " + type);
+        return new UpgradeData { type = type, cost = 0, effect = 0f };
+    }
+
+    // Restores coin and upgrade values from PlayerPrefs.
+    private void LoadState()
+    {
+        Coins = PlayerPrefs.GetInt(CoinsKey, 0);
+        foreach (var up in availableUpgrades)
+        {
+            int level = PlayerPrefs.GetInt(UpgradePrefix + up.type, 0);
+            upgradeLevels[up.type] = level;
+        }
+    }
+
+    // Writes the current coin amount and upgrade levels to PlayerPrefs.
+    private void SaveState()
+    {
+        PlayerPrefs.SetInt(CoinsKey, Coins);
+        foreach (var kvp in upgradeLevels)
+        {
+            PlayerPrefs.SetInt(UpgradePrefix + kvp.Key, kvp.Value);
+        }
+        PlayerPrefs.Save();
+    }
+}

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -26,6 +26,7 @@ public class UIManager : MonoBehaviour
     public GameObject leaderboardPanel;
     public Text leaderboardText;
     public GameObject workshopPanel;
+    public GameObject shopPanel;
     public Text workshopListText;
     [Tooltip("External form URL for player feedback. Leave blank to hide the button.")]
     public string feedbackUrl = "";
@@ -112,6 +113,7 @@ public class UIManager : MonoBehaviour
         HidePanelImmediate(pausePanel);
         HidePanelImmediate(leaderboardPanel);
         HidePanelImmediate(workshopPanel);
+        HidePanelImmediate(shopPanel);
         HidePanelImmediate(settingsPanel);
         if (GameManager.Instance != null)
         {
@@ -257,6 +259,22 @@ public class UIManager : MonoBehaviour
     public void HideWorkshop()
     {
         HidePanel(workshopPanel);
+    }
+
+    /// <summary>
+    /// Displays the shop panel where upgrades can be purchased.
+    /// </summary>
+    public void ShowShop()
+    {
+        ShowPanel(shopPanel);
+    }
+
+    /// <summary>
+    /// Hides the shop panel.
+    /// </summary>
+    public void HideShop()
+    {
+        HidePanel(shopPanel);
     }
 
     /// <summary>

--- a/Assets/Scripts/UpgradeType.cs
+++ b/Assets/Scripts/UpgradeType.cs
@@ -1,0 +1,11 @@
+using System;
+
+/// <summary>
+/// Enumerates all upgrade categories recognized by <see cref="ShopManager"/>.
+/// Values are used as keys when persisting upgrade levels to PlayerPrefs.
+/// </summary>
+public enum UpgradeType
+{
+    /// <summary>Extends the duration of the magnet power-up.</summary>
+    MagnetDuration = 0
+}

--- a/Assets/Tests/EditMode/ShopManagerTests.cs
+++ b/Assets/Tests/EditMode/ShopManagerTests.cs
@@ -1,0 +1,101 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tests verifying the persistent upgrade and coin logic of <see cref="ShopManager"/>.
+/// </summary>
+public class ShopManagerTests
+{
+    [Test]
+    public void AddCoins_PersistsTotal()
+    {
+        PlayerPrefs.DeleteAll();
+        var go = new GameObject("shop");
+        var sm = go.AddComponent<ShopManager>();
+        sm.availableUpgrades = new ShopManager.UpgradeData[0];
+
+        // Reload state now that upgrades are assigned
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        sm.AddCoins(5);
+        Object.DestroyImmediate(go);
+
+        var go2 = new GameObject("shop2");
+        var sm2 = go2.AddComponent<ShopManager>();
+        sm2.availableUpgrades = new ShopManager.UpgradeData[0];
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm2, null);
+
+        Assert.AreEqual(5, sm2.Coins);
+        Object.DestroyImmediate(go2);
+    }
+
+    [Test]
+    public void PurchaseUpgrade_DeductsCoinsAndSavesLevel()
+    {
+        PlayerPrefs.DeleteAll();
+        var data = new ShopManager.UpgradeData { type = UpgradeType.MagnetDuration, cost = 3, effect = 1f };
+
+        var go = new GameObject("shop");
+        var sm = go.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        sm.AddCoins(5);
+        bool bought = sm.PurchaseUpgrade(UpgradeType.MagnetDuration);
+
+        Assert.IsTrue(bought);
+        Assert.AreEqual(2, sm.Coins);
+        Assert.AreEqual(1f, sm.GetUpgradeEffect(UpgradeType.MagnetDuration));
+        Object.DestroyImmediate(go);
+
+        var go2 = new GameObject("shop2");
+        var sm2 = go2.AddComponent<ShopManager>();
+        sm2.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm2, null);
+
+        Assert.AreEqual(1f, sm2.GetUpgradeEffect(UpgradeType.MagnetDuration));
+        Object.DestroyImmediate(go2);
+    }
+
+    [Test]
+    public void MagnetPowerUp_UsesUpgradeEffect()
+    {
+        PlayerPrefs.DeleteAll();
+        var data = new ShopManager.UpgradeData { type = UpgradeType.MagnetDuration, cost = 1, effect = 1f };
+
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        // Manually set upgrade level to simulate a previous purchase
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.MagnetDuration] = 1;
+        dictField.SetValue(sm, levels);
+
+        var player = new GameObject("player");
+        player.tag = "Player";
+        var magnet = player.AddComponent<CoinMagnet>();
+        var playerCol = player.AddComponent<BoxCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var mp = powerObj.AddComponent<MagnetPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+        mp.duration = 2f;
+
+        mp.OnTriggerEnter2D(playerCol);
+
+        var timerField = typeof(CoinMagnet).GetField("magnetTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(magnet);
+
+        Assert.AreEqual(3f, timer);
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(shopObj);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ A 2D endless runner built with Unity. This repository contains basic scripts for
     - `WorkshopManager` uploads and downloads level or skin packs from the Steam Workshop.
     - `ObjectPool` provides reusable objects for the spawners.
     - `AnalyticsManager` logs run data locally and can post it to a remote URL you provide.
+   - `ShopManager` persists coins and upgrades so players can buy bonuses between runs.
 4. Add prefabs for your player, obstacles, hazards, and coins, then assign them in the inspector. Link the coin label and combo label fields of `GameManager` to UI Text elements.
-5. Tag any obstacle or hazard prefab with **Obstacle** or **Hazard** so collisions trigger a restart. Tag coin prefabs with **Coin** so they can be collected.
-6. Press Play to run the game. Use the start menu's **Play** button to begin. Press **Esc** during play to pause and resume. The score counts how far you travel and the speed increases over time. Collect coins for bonus points—grabbing several in quick succession will build a combo that multiplies their value. If the player hits an obstacle or hazard, a game-over screen shows your distance, coin total, and the best score so far, allowing you to restart.
-
+5. Create a GameObject with the `ShopManager` script so coins and upgrades persist between runs. Add a shop panel and assign it to `UIManager.shopPanel`.
+6. Tag any obstacle or hazard prefab with **Obstacle** or **Hazard** so collisions trigger a restart. Tag coin prefabs with **Coin** so they can be collected.
+7. Press Play to run the game. Use the start menu's **Play** button to begin. Press **Esc** during play to pause and resume. The score counts how far you travel and the speed increases over time. Collect coins for bonus points—grabbing several in quick succession will build a combo that multiplies their value. If the player hits an obstacle or hazard, a game-over screen shows your distance, coin total, and the best score so far, allowing you to restart.
 ## Additional Setup Steps
 This repository only provides the C# scripts. No assets or `ProjectSettings`
 are included, so you must configure a new Unity project yourself before the
@@ -70,6 +71,7 @@ with your app's ID so Steamworks initializes correctly.
 - Add a `StageManager` object and assign background sprite names and obstacle
   prefabs for each stage. The manager listens to `GameManager.OnStageUnlocked`
   and swaps the active background plus spawner lists when new stages begin.
+- Include a shop panel in the canvas and wire its buttons to `UIManager.ShowShop` and `UIManager.HideShop`.
 This project now includes simple menus, audio hooks, and escalating difficulty but you can further expand it with custom art, music, and polished effects.
 ## Stage Configuration
 `GameManager` uses the `stageGoals` array to determine when stages unlock.


### PR DESCRIPTION
## Summary
- implement `ShopManager` with PlayerPrefs persistence
- add `UpgradeType` enum
- increase `MagnetPowerUp` duration when upgrades are purchased
- deposit run coins into `ShopManager` on game over
- extend `UIManager` with a shop panel
- document new shop setup in README
- test upgrade persistence and magnet duration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9f58d40483219f879eccfedf48de