### PR TITLE
Integrate new input system

### DIFF
--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -1,21 +1,62 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 /// <summary>
-/// Manages customizable key bindings saved in PlayerPrefs.
+/// Centralised helper for reading player input. This file was expanded to
+/// support Unity's new Input System package while retaining the original
+/// KeyCode-based approach. When <c>ENABLE_INPUT_SYSTEM</c> is defined, input is
+/// read through <see cref="InputAction"/> instances that expose jump, slide and
+/// pause actions with keyboard and gamepad bindings. If the package is not
+/// present the manager falls back to legacy <see cref="KeyCode"/> queries.
+/// Key bindings are saved to <see cref="PlayerPrefs"/>.
 /// </summary>
 public static class InputManager
 {
     private const string JumpPref = "JumpKey";
     private const string SlidePref = "SlideKey";
+    private const string PausePref = "PauseKey";
+#if ENABLE_INPUT_SYSTEM
+    private const string JumpBindingPref = "JumpBinding";
+    private const string SlideBindingPref = "SlideBinding";
+    private const string PauseBindingPref = "PauseBinding";
 
+    // InputActions used when the new Input System package is present.
+    private static InputAction jumpAction;
+    private static InputAction slideAction;
+    private static InputAction pauseAction;
+#endif
+
+    // Fallback KeyCodes used when the new Input System isn't available.
     public static KeyCode JumpKey { get; private set; }
     public static KeyCode SlideKey { get; private set; }
+    public static KeyCode PauseKey { get; private set; }
 
     static InputManager()
     {
         // Load keys from prefs or use defaults
         JumpKey = LoadKey(JumpPref, KeyCode.Space);
         SlideKey = LoadKey(SlidePref, KeyCode.LeftControl);
+        PauseKey = LoadKey(PausePref, KeyCode.Escape);
+
+#if ENABLE_INPUT_SYSTEM
+        // Setup actions so either keyboard or gamepad can trigger them.
+        jumpAction = new InputAction("Jump", InputActionType.Button);
+        jumpAction.AddBinding(PlayerPrefs.GetString(JumpBindingPref, "<Keyboard>/space"));
+        jumpAction.AddBinding("<Gamepad>/buttonSouth");
+        jumpAction.Enable();
+
+        slideAction = new InputAction("Slide", InputActionType.Button);
+        slideAction.AddBinding(PlayerPrefs.GetString(SlideBindingPref, "<Keyboard>/leftCtrl"));
+        slideAction.AddBinding("<Gamepad>/buttonEast");
+        slideAction.Enable();
+
+        pauseAction = new InputAction("Pause", InputActionType.Button);
+        pauseAction.AddBinding(PlayerPrefs.GetString(PauseBindingPref, "<Keyboard>/escape"));
+        pauseAction.AddBinding("<Gamepad>/start");
+        pauseAction.Enable();
+#endif
     }
 
     /// <summary>
@@ -50,5 +91,151 @@ public static class InputManager
         SlideKey = key;
         PlayerPrefs.SetString(SlidePref, key.ToString());
         PlayerPrefs.Save();
+    }
+
+    /// <summary>
+    /// Saves the provided key as the new pause binding.
+    /// </summary>
+    public static void SetPauseKey(KeyCode key)
+    {
+        PauseKey = key;
+        PlayerPrefs.SetString(PausePref, key.ToString());
+        PlayerPrefs.Save();
+    }
+
+#if ENABLE_INPUT_SYSTEM
+    /// <summary>
+    /// Begins an interactive rebinding operation for the jump action.
+    /// The provided MonoBehaviour is used to start a coroutine so the
+    /// operation can run asynchronously. The label is updated with the
+    /// human readable binding string when complete.
+    /// </summary>
+    public static void StartRebindJump(MonoBehaviour owner, UnityEngine.UI.Text label)
+    {
+        owner.StartCoroutine(RebindRoutine(jumpAction, JumpBindingPref, label));
+    }
+
+    /// <summary>
+    /// Begins an interactive rebinding operation for the slide action.
+    /// </summary>
+    public static void StartRebindSlide(MonoBehaviour owner, UnityEngine.UI.Text label)
+    {
+        owner.StartCoroutine(RebindRoutine(slideAction, SlideBindingPref, label));
+    }
+
+    /// <summary>
+    /// Begins an interactive rebinding operation for the pause action.
+    /// </summary>
+    public static void StartRebindPause(MonoBehaviour owner, UnityEngine.UI.Text label)
+    {
+        owner.StartCoroutine(RebindRoutine(pauseAction, PauseBindingPref, label));
+    }
+
+    // Coroutine that waits for the user to press a new control and stores the result.
+    private static System.Collections.IEnumerator RebindRoutine(InputAction action, string pref, UnityEngine.UI.Text label)
+    {
+        action.Disable();
+        var operation = action.PerformInteractiveRebinding()
+            .WithControlsExcluding("Mouse")
+            .OnComplete(op =>
+            {
+                action.Enable();
+                op.Dispose();
+                string path = action.bindings[0].effectivePath;
+                PlayerPrefs.SetString(pref, path);
+                PlayerPrefs.Save();
+                if (label != null)
+                {
+                    label.text = InputControlPath.ToHumanReadableString(path, InputControlPath.HumanReadableStringOptions.OmitDevice);
+                }
+            });
+
+        while (!operation.completed)
+            yield return null;
+    }
+#endif
+
+    /// <summary>
+    /// Returns true during the frame the jump input is pressed.
+    /// </summary>
+    public static bool GetJumpDown()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (jumpAction != null)
+        {
+            return jumpAction.WasPressedThisFrame();
+        }
+#endif
+        return Input.GetKeyDown(JumpKey);
+    }
+
+    /// <summary>
+    /// Returns true while the jump input is held.
+    /// </summary>
+    public static bool GetJump()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (jumpAction != null)
+        {
+            return jumpAction.IsPressed();
+        }
+#endif
+        return Input.GetKey(JumpKey);
+    }
+
+    /// <summary>
+    /// Returns true the frame the jump input is released.
+    /// </summary>
+    public static bool GetJumpUp()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (jumpAction != null)
+        {
+            return jumpAction.WasReleasedThisFrame();
+        }
+#endif
+        return Input.GetKeyUp(JumpKey);
+    }
+
+    /// <summary>
+    /// Returns true during the frame the slide input is pressed.
+    /// </summary>
+    public static bool GetSlideDown()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (slideAction != null)
+        {
+            return slideAction.WasPressedThisFrame();
+        }
+#endif
+        return Input.GetKeyDown(SlideKey);
+    }
+
+    /// <summary>
+    /// Returns true while the slide input is held.
+    /// </summary>
+    public static bool GetSlide()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (slideAction != null)
+        {
+            return slideAction.IsPressed();
+        }
+#endif
+        return Input.GetKey(SlideKey);
+    }
+
+    /// <summary>
+    /// Returns true during the frame the pause input is pressed.
+    /// </summary>
+    public static bool GetPauseDown()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (pauseAction != null)
+        {
+            return pauseAction.WasPressedThisFrame();
+        }
+#endif
+        return Input.GetKeyDown(PauseKey);
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,9 +1,11 @@
 using UnityEngine;
 
 /// <summary>
-/// Handles all player movement including jumping, variable jump height,
-/// sliding and collision responses. Uses simple physics based controls
-/// and communicates with the <see cref="GameManager"/> for game state.
+/// Handles all player movement including jumping, variable jump height, sliding
+/// and collision responses. The controller now queries input through
+/// <see cref="InputManager"/> so it works with both the new Input System and the
+/// legacy input manager. Uses simple physics based controls and communicates
+/// with the <see cref="GameManager"/> for game state.
 /// </summary>
 public class PlayerController : MonoBehaviour
 {
@@ -59,11 +61,11 @@ public class PlayerController : MonoBehaviour
         CheckGrounded();
 
         // Handle jump input and variable jump height using custom bindings
-        if (Input.GetKeyDown(InputManager.JumpKey))
+        if (InputManager.GetJumpDown())
         {
             AttemptJump();
         }
-        if (Input.GetKey(InputManager.JumpKey) && isJumping)
+        if (InputManager.GetJump() && isJumping)
         {
             // Apply extra upward force while the jump button is held
             if (variableJumpTimer > 0f)
@@ -72,12 +74,12 @@ public class PlayerController : MonoBehaviour
                 variableJumpTimer -= Time.deltaTime;
             }
         }
-        if (Input.GetKeyUp(InputManager.JumpKey))
+        if (InputManager.GetJumpUp())
         {
             isJumping = false;
         }
 
-        if (Input.GetKeyDown(InputManager.SlideKey))
+        if (InputManager.GetSlideDown())
         {
             StartSlide();
         }

--- a/Assets/Scripts/SettingsMenu.cs
+++ b/Assets/Scripts/SettingsMenu.cs
@@ -2,12 +2,15 @@ using UnityEngine;
 using UnityEngine.UI;
 
 /// <summary>
-/// Provides UI hooks for changing key bindings and colorblind mode.
+/// Provides UI hooks for changing key bindings and colorblind mode. When the
+/// new Input System package is installed the menu can start interactive
+/// rebinding operations so players can customise controls at runtime.
 /// </summary>
 public class SettingsMenu : MonoBehaviour
 {
     public Text jumpKeyLabel;
     public Text slideKeyLabel;
+    public Text pauseKeyLabel;
     public Toggle colorblindToggle;
 
     /// <summary>
@@ -17,6 +20,7 @@ public class SettingsMenu : MonoBehaviour
     {
         if (jumpKeyLabel != null) jumpKeyLabel.text = InputManager.JumpKey.ToString();
         if (slideKeyLabel != null) slideKeyLabel.text = InputManager.SlideKey.ToString();
+        if (pauseKeyLabel != null) pauseKeyLabel.text = InputManager.PauseKey.ToString();
         if (colorblindToggle != null) colorblindToggle.isOn = ColorblindManager.Enabled;
     }
 
@@ -33,6 +37,18 @@ public class SettingsMenu : MonoBehaviour
     }
 
     /// <summary>
+    /// Updates the pause key binding based on a UI selection.
+    /// </summary>
+    public void SetPauseKey(string keyName)
+    {
+        if (System.Enum.TryParse(keyName, out KeyCode key))
+        {
+            InputManager.SetPauseKey(key);
+            if (pauseKeyLabel != null) pauseKeyLabel.text = key.ToString();
+        }
+    }
+
+    /// <summary>
     /// Updates the slide key binding based on a UI selection.
     /// </summary>
     public void SetSlideKey(string keyName)
@@ -43,6 +59,31 @@ public class SettingsMenu : MonoBehaviour
             if (slideKeyLabel != null) slideKeyLabel.text = key.ToString();
         }
     }
+#if ENABLE_INPUT_SYSTEM
+    /// <summary>
+    /// Begins rebinding for the jump action using the new Input System.
+    /// </summary>
+    public void RebindJump()
+    {
+        InputManager.StartRebindJump(this, jumpKeyLabel);
+    }
+
+    /// <summary>
+    /// Begins rebinding for the slide action.
+    /// </summary>
+    public void RebindSlide()
+    {
+        InputManager.StartRebindSlide(this, slideKeyLabel);
+    }
+
+    /// <summary>
+    /// Begins rebinding for the pause action.
+    /// </summary>
+    public void RebindPause()
+    {
+        InputManager.StartRebindPause(this, pauseKeyLabel);
+    }
+#endif
 
     /// <summary>
     /// Enables or disables colorblind mode from the toggle.

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -10,9 +10,11 @@ using System.IO;
 using System.Linq;
 
 /// <summary>
-/// Manages the game's simple UI screens such as the start menu, pause menu
-/// and game-over display. Interfaces with the <see cref="GameManager"/> to
-/// start, pause and restart the game.
+/// Manages the game's simple UI screens such as the start menu, pause menu and
+/// game-over display. Input listening for the pause command now routes through
+/// <see cref="InputManager"/> so players can rebind the action with the new
+/// Input System. Interfaces with the <see cref="GameManager"/> to start, pause
+/// and restart the game.
 /// </summary>
 public class UIManager : MonoBehaviour
 {
@@ -88,8 +90,8 @@ public class UIManager : MonoBehaviour
     /// </summary>
     void Update()
     {
-        // Toggle pause state when the Escape key is pressed during a run
-        if (Input.GetKeyDown(KeyCode.Escape) && GameManager.Instance != null && GameManager.Instance.IsRunning())
+        // Toggle pause state when the configured pause input is pressed during a run
+        if (InputManager.GetPauseDown() && GameManager.Instance != null && GameManager.Instance.IsRunning())
         {
             if (GameManager.Instance.IsPaused())
             {

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UnityEngine;
+
+/// <summary>
+/// Tests verifying that <see cref="InputManager"/> correctly loads and stores
+/// key bindings. These tests cover the KeyCode fallback behaviour so they run
+/// even when the new Input System package is absent.
+/// </summary>
+public class InputManagerTests
+{
+    [SetUp]
+    public void ClearPrefs()
+    {
+        PlayerPrefs.DeleteAll();
+    }
+
+    [Test]
+    public void Defaults_AreLoaded_WhenPrefsMissing()
+    {
+        Assert.AreEqual(KeyCode.Space, InputManager.JumpKey);
+        Assert.AreEqual(KeyCode.LeftControl, InputManager.SlideKey);
+        Assert.AreEqual(KeyCode.Escape, InputManager.PauseKey);
+    }
+
+    [Test]
+    public void SetJumpKey_PersistsValue()
+    {
+        InputManager.SetJumpKey(KeyCode.Z);
+        Assert.AreEqual(KeyCode.Z, InputManager.JumpKey);
+        Assert.AreEqual("Z", PlayerPrefs.GetString("JumpKey"));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ data remains on the player's machine.  A `feedbackUrl` on `UIManager` can open
 an external survey or bug‑report form to collect additional feedback from
 players.
 
+## Input System Setup
+This project now supports Unity's **Input System** package. Install the package
+through the Package Manager and enable the *Input System Package* when prompted.
+The `InputManager` script exposes actions for **jump**, **slide**, and **pause**
+which automatically map to both keyboard and gamepad controls. If the package is
+not installed the scripts fall back to the legacy `KeyCode` input checks.
+Rebinding can be triggered from the in-game settings menu when the new system is
+available.
+
 ## Running Edit Mode Tests
 This repository includes a small suite of EditMode tests.
 


### PR DESCRIPTION
## Summary
- support Unity Input System while keeping KeyCode fallback
- bind jump, slide and pause actions with keyboard and gamepad
- allow rebinding through `SettingsMenu` when using Input System
- update player and UI code to read input via `InputManager`
- document new setup instructions
- add tests for `InputManager` persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd254a7888321a5497319c1c40975