### PR TITLE
Add new upgrade types and apply bonuses

### DIFF
--- a/Assets/Scripts/Coin.cs
+++ b/Assets/Scripts/Coin.cs
@@ -13,7 +13,8 @@ public class Coin : MonoBehaviour
     /// <summary>
     /// Triggered when another collider enters the coin's trigger. If the
     /// collider belongs to the player, coins are added and the object is
-    /// either returned to its pool or destroyed.
+    /// either returned to its pool or destroyed. The final value includes
+    /// any combo or upgrade bonuses handled by <see cref="GameManager.AddCoins"/>.
     /// </summary>
     void OnTriggerEnter2D(Collider2D other)
     {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -353,7 +353,8 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Adds to the player's coin tally and updates the UI label.
+    /// Adds to the player's coin tally and updates the UI label. Coin value may
+    /// increase through both the combo system and any purchased upgrades.
     /// </summary>
     public void AddCoins(int amount)
     {
@@ -375,7 +376,16 @@ public class GameManager : MonoBehaviour
 
         coinComboTimer = comboDuration; // reset the combo window
 
-        coins += amount * coinComboMultiplier;
+        // Incorporate any purchased coin multiplier upgrade. Each upgrade level
+        // adds a fixed bonus value to every coin pickup.
+        float bonus = 0f;
+        if (ShopManager.Instance != null)
+        {
+            bonus = ShopManager.Instance.GetUpgradeEffect(UpgradeType.CoinMultiplier);
+        }
+
+        // Final value after combo and upgrade bonuses are applied.
+        coins += Mathf.RoundToInt((amount + bonus) * coinComboMultiplier);
         UpdateCoinLabel();
         UpdateMultiplierLabel();
     }

--- a/Assets/Scripts/ShieldPowerUp.cs
+++ b/Assets/Scripts/ShieldPowerUp.cs
@@ -18,7 +18,13 @@ public class ShieldPowerUp : MonoBehaviour
             PlayerShield shield = other.GetComponent<PlayerShield>();
             if (shield != null)
             {
-                shield.ActivateShield(duration);
+                // Extend the shield duration by any purchased upgrade.
+                float totalDuration = duration;
+                if (ShopManager.Instance != null)
+                {
+                    totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.ShieldDuration);
+                }
+                shield.ActivateShield(totalDuration);
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Scripts/ShopManager.cs
+++ b/Assets/Scripts/ShopManager.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 /// <summary>
 /// Central shop system that persists the player's coin total and purchased
 /// upgrades between sessions using PlayerPrefs. Each upgrade increases a
-/// gameplay value such as power-up duration.
+/// gameplay value such as power-up duration. Supported upgrades include
+/// extending magnet, speed boost, and shield times along with adding a coin
+/// value bonus.
 /// </summary>
 public class ShopManager : MonoBehaviour
 {
@@ -19,7 +21,9 @@ public class ShopManager : MonoBehaviour
     {
         public UpgradeType type;  // unique identifier for the upgrade
         public int cost;          // cost in coins per purchase
-        public float effect;      // effect added per upgrade level
+        // For duration upgrades this is the number of seconds added per level.
+        // For coin upgrades this is the extra value granted per pickup.
+        public float effect;
     }
 
     [Tooltip("Upgrades players can buy in the shop.")]

--- a/Assets/Scripts/SpeedBoostPowerUp.cs
+++ b/Assets/Scripts/SpeedBoostPowerUp.cs
@@ -20,7 +20,14 @@ public class SpeedBoostPowerUp : MonoBehaviour
         {
             if (GameManager.Instance != null)
             {
-                GameManager.Instance.ActivateSpeedBoost(duration, speedMultiplier);
+                // Add any purchased upgrade effect to the base duration so
+                // higher levels extend the boost time.
+                float totalDuration = duration;
+                if (ShopManager.Instance != null)
+                {
+                    totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.SpeedBoostDuration);
+                }
+                GameManager.Instance.ActivateSpeedBoost(totalDuration, speedMultiplier);
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Scripts/UpgradeType.cs
+++ b/Assets/Scripts/UpgradeType.cs
@@ -3,9 +3,20 @@ using System;
 /// <summary>
 /// Enumerates all upgrade categories recognized by <see cref="ShopManager"/>.
 /// Values are used as keys when persisting upgrade levels to PlayerPrefs.
+/// The enum started with only <see cref="MagnetDuration"/> but has been
+/// extended to cover additional power-ups and coin bonuses.
 /// </summary>
 public enum UpgradeType
 {
     /// <summary>Extends the duration of the magnet power-up.</summary>
-    MagnetDuration = 0
+    MagnetDuration = 0,
+
+    /// <summary>Additional seconds applied to <see cref="SpeedBoostPowerUp"/>.</summary>
+    SpeedBoostDuration = 1,
+
+    /// <summary>Additional seconds applied to <see cref="ShieldPowerUp"/>.</summary>
+    ShieldDuration = 2,
+
+    /// <summary>Extra coins awarded for each pickup.</summary>
+    CoinMultiplier = 3
 }

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -63,4 +63,31 @@ public class GameManagerTests
         Assert.AreEqual(4, gm.GetCoins());
         Object.DestroyImmediate(go);
     }
+
+    [Test]
+    public void AddCoins_AppliesUpgradeMultiplier()
+    {
+        PlayerPrefs.DeleteAll();
+        var data = new ShopManager.UpgradeData { type = UpgradeType.CoinMultiplier, cost = 1, effect = 1f };
+
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.CoinMultiplier] = 1;
+        dictField.SetValue(sm, levels);
+
+        var go = new GameObject("gm");
+        var gm = go.AddComponent<GameManager>();
+
+        gm.AddCoins(1);
+
+        Assert.AreEqual(2, gm.GetCoins());
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(shopObj);
+    }
 }

--- a/Assets/Tests/EditMode/ShopManagerTests.cs
+++ b/Assets/Tests/EditMode/ShopManagerTests.cs
@@ -98,4 +98,85 @@ public class ShopManagerTests
         Object.DestroyImmediate(player);
         Object.DestroyImmediate(shopObj);
     }
+
+    [Test]
+    public void SpeedBoostPowerUp_UsesUpgradeEffect()
+    {
+        PlayerPrefs.DeleteAll();
+        var data = new ShopManager.UpgradeData { type = UpgradeType.SpeedBoostDuration, cost = 1, effect = 1f };
+
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.SpeedBoostDuration] = 1;
+        dictField.SetValue(sm, levels);
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+
+        var player = new GameObject("player");
+        player.tag = "Player";
+        var playerCol = player.AddComponent<BoxCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var sb = powerObj.AddComponent<SpeedBoostPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+        sb.duration = 2f;
+
+        sb.OnTriggerEnter2D(playerCol);
+
+        var timerField = typeof(GameManager).GetField("speedBoostTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(gm);
+
+        Assert.AreEqual(3f, timer);
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(shopObj);
+    }
+
+    [Test]
+    public void ShieldPowerUp_UsesUpgradeEffect()
+    {
+        PlayerPrefs.DeleteAll();
+        var data = new ShopManager.UpgradeData { type = UpgradeType.ShieldDuration, cost = 1, effect = 1f };
+
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.ShieldDuration] = 1;
+        dictField.SetValue(sm, levels);
+
+        var player = new GameObject("player");
+        player.tag = "Player";
+        var shield = player.AddComponent<PlayerShield>();
+        var playerCol = player.AddComponent<BoxCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var sp = powerObj.AddComponent<ShieldPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+        sp.duration = 2f;
+
+        sp.OnTriggerEnter2D(playerCol);
+
+        var timerField = typeof(PlayerShield).GetField("shieldTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(shield);
+
+        Assert.AreEqual(3f, timer);
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(shopObj);
+    }
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A 2D endless runner built with Unity. This repository contains basic scripts for
     - `WorkshopManager` uploads and downloads level or skin packs from the Steam Workshop.
     - `ObjectPool` provides reusable objects for the spawners.
     - `AnalyticsManager` logs run data locally and can post it to a remote URL you provide.
-   - `ShopManager` persists coins and upgrades so players can buy bonuses between runs.
+   - `ShopManager` persists coins and upgrades so players can buy bonuses between runs. Upgrades currently extend power-up durations (magnet, speed boost, shield) and award extra coins per pickup.
 4. Add prefabs for your player, obstacles, hazards, and coins, then assign them in the inspector. Link the coin label and combo label fields of `GameManager` to UI Text elements.
 5. Create a GameObject with the `ShopManager` script so coins and upgrades persist between runs. Add a shop panel and assign it to `UIManager.shopPanel`.
 6. Tag any obstacle or hazard prefab with **Obstacle** or **Hazard** so collisions trigger a restart. Tag coin prefabs with **Coin** so they can be collected.


### PR DESCRIPTION
## Summary
- extend `UpgradeType` with new entries
- document new upgrade system in `ShopManager`
- apply duration upgrades in `SpeedBoostPowerUp` and `ShieldPowerUp`
- support coin multiplier in `GameManager.AddCoins`
- clarify coin collection docs
- update README
- add unit tests for new upgrade functionality

## Testing
- `npm test`