### PR TITLE
Add daily challenge system

### DIFF
--- a/Assets/Scripts/DailyChallengeManager.cs
+++ b/Assets/Scripts/DailyChallengeManager.cs
@@ -1,0 +1,201 @@
+using UnityEngine;
+using System;
+
+/// <summary>
+/// Generates and tracks a single daily challenge. The challenge persists in
+/// PlayerPrefs with an expiry timestamp so players receive a new objective
+/// each day they launch the game. Goals may involve traveling a distance,
+/// collecting coins or using a specific power-up. Progress is monitored
+/// through <see cref="GameManager"/> statistics.
+/// </summary>
+public class DailyChallengeManager : MonoBehaviour
+{
+    /// <summary>Types of objectives a challenge can generate.</summary>
+    public enum ChallengeType { Distance, Coins, PowerUpUse }
+
+    /// <summary>Supported power-up identifiers for power-up challenges.</summary>
+    public enum PowerUpType { Magnet, SpeedBoost, Shield, GravityFlip }
+
+    [Serializable]
+    private class ChallengeState
+    {
+        public ChallengeType type;    // kind of goal to complete
+        public PowerUpType powerUp;   // power-up to use when type is PowerUpUse
+        public int target;            // required amount (distance, coins or uses)
+        public int progress;          // current progress toward the goal
+        public long expires;          // UTC ticks when a new challenge should be generated
+        public bool completed;        // true once the reward has been granted
+    }
+
+    private const string PrefKey = "DailyChallengeData";
+    private const int RewardCoins = 25;                    // coins awarded on completion
+    private const string AchComplete = "ACH_DAILY_COMPLETE";
+
+    public static DailyChallengeManager Instance { get; private set; }
+
+    private ChallengeState state;
+
+    /// <summary>
+    /// Initializes the singleton instance and loads or creates the current
+    /// challenge data.
+    /// </summary>
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            LoadOrGenerate();
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    /// <summary>
+    /// Checks for completion each frame by comparing GameManager metrics
+    /// against the active challenge.
+    /// </summary>
+    void Update()
+    {
+        if (state == null || state.completed)
+            return;
+
+        if (state.expires <= DateTime.UtcNow.Ticks)
+        {
+            GenerateChallenge();
+            return;
+        }
+
+        switch (state.type)
+        {
+            case ChallengeType.Distance:
+                if (GameManager.Instance != null)
+                {
+                    state.progress = Mathf.FloorToInt(GameManager.Instance.GetDistance());
+                }
+                break;
+            case ChallengeType.Coins:
+                if (GameManager.Instance != null)
+                {
+                    state.progress = GameManager.Instance.GetCoins();
+                }
+                break;
+        }
+
+        if (state.progress >= state.target)
+        {
+            CompleteChallenge();
+        }
+    }
+
+    /// <summary>
+    /// Records usage of a power-up so power-up challenges can progress.
+    /// </summary>
+    public void RecordPowerUpUse(PowerUpType type)
+    {
+        if (state == null || state.completed)
+            return;
+        if (state.type == ChallengeType.PowerUpUse && state.powerUp == type)
+        {
+            state.progress++;
+            if (state.progress >= state.target)
+            {
+                CompleteChallenge();
+            }
+            else
+            {
+                SaveState();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns a human readable description of the current challenge.
+    /// </summary>
+    public string GetChallengeText()
+    {
+        if (state == null)
+            return string.Empty;
+        switch (state.type)
+        {
+            case ChallengeType.Distance:
+                return $"Travel {state.target}m";
+            case ChallengeType.Coins:
+                return $"Collect {state.target} coins";
+            case ChallengeType.PowerUpUse:
+                return $"Use {state.powerUp} {state.target} times";
+            default:
+                return string.Empty;
+        }
+    }
+
+    /// <summary>Current progress value for UI display.</summary>
+    public int GetProgress() => state?.progress ?? 0;
+    /// <summary>Goal value for UI display.</summary>
+    public int GetTarget() => state?.target ?? 0;
+    /// <summary>Whether the player has finished today's challenge.</summary>
+    public bool IsCompleted() => state?.completed ?? false;
+
+    // Loads the challenge from PlayerPrefs or creates a new one when missing or expired.
+    private void LoadOrGenerate()
+    {
+        if (PlayerPrefs.HasKey(PrefKey))
+        {
+            string json = PlayerPrefs.GetString(PrefKey);
+            state = JsonUtility.FromJson<ChallengeState>(json);
+            if (state == null || state.expires <= DateTime.UtcNow.Ticks)
+            {
+                GenerateChallenge();
+            }
+        }
+        else
+        {
+            GenerateChallenge();
+        }
+    }
+
+    // Creates a new random challenge and saves it to PlayerPrefs.
+    private void GenerateChallenge()
+    {
+        state = new ChallengeState();
+        state.type = (ChallengeType)UnityEngine.Random.Range(0, Enum.GetNames(typeof(ChallengeType)).Length);
+        state.target = state.type switch
+        {
+            ChallengeType.Distance => UnityEngine.Random.Range(500, 2000),
+            ChallengeType.Coins => UnityEngine.Random.Range(10, 100),
+            ChallengeType.PowerUpUse => UnityEngine.Random.Range(1, 3),
+            _ => 0
+        };
+        state.powerUp = (PowerUpType)UnityEngine.Random.Range(0, Enum.GetNames(typeof(PowerUpType)).Length);
+        state.progress = 0;
+        state.completed = false;
+        state.expires = DateTime.UtcNow.AddDays(1).Ticks;
+        SaveState();
+    }
+
+    // Writes the current state to PlayerPrefs for persistence across sessions.
+    private void SaveState()
+    {
+        if (state == null) return;
+        string json = JsonUtility.ToJson(state);
+        PlayerPrefs.SetString(PrefKey, json);
+        PlayerPrefs.Save();
+    }
+
+    // Grants the reward and flags the challenge as complete.
+    private void CompleteChallenge()
+    {
+        state.completed = true;
+        SaveState();
+        if (ShopManager.Instance != null)
+        {
+            ShopManager.Instance.AddCoins(RewardCoins);
+        }
+        if (SteamManager.Instance != null)
+        {
+            SteamManager.Instance.UnlockAchievement(AchComplete);
+        }
+    }
+}

--- a/Assets/Scripts/DailyChallengeUI.cs
+++ b/Assets/Scripts/DailyChallengeUI.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Simple UI component that displays the current daily challenge text and
+/// progress percentage. Attach this script to a panel containing a Text field
+/// and optional progress slider.
+/// </summary>
+public class DailyChallengeUI : MonoBehaviour
+{
+    public Text challengeLabel;
+    public Slider progressBar;
+
+    void Update()
+    {
+        if (DailyChallengeManager.Instance == null)
+            return;
+
+        challengeLabel.text = DailyChallengeManager.Instance.GetChallengeText();
+
+        int target = DailyChallengeManager.Instance.GetTarget();
+        int progress = DailyChallengeManager.Instance.GetProgress();
+        if (progressBar != null && target > 0)
+        {
+            progressBar.value = Mathf.Clamp01(progress / (float)target);
+        }
+    }
+}

--- a/Assets/Scripts/GravityFlipPowerUp.cs
+++ b/Assets/Scripts/GravityFlipPowerUp.cs
@@ -18,6 +18,11 @@ public class GravityFlipPowerUp : MonoBehaviour
             if (GameManager.Instance != null)
             {
                 GameManager.Instance.ActivateGravityFlip(duration);
+                // Log the usage for daily challenges
+                if (DailyChallengeManager.Instance != null)
+                {
+                    DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.GravityFlip);
+                }
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Scripts/MagnetPowerUp.cs
+++ b/Assets/Scripts/MagnetPowerUp.cs
@@ -27,6 +27,11 @@ public class MagnetPowerUp : MonoBehaviour
                     totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.MagnetDuration);
                 }
                 magnet.ActivateMagnet(totalDuration);
+                // Notify the DailyChallengeManager so magnet use can count toward challenges
+                if (DailyChallengeManager.Instance != null)
+                {
+                    DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.Magnet);
+                }
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Scripts/ShieldPowerUp.cs
+++ b/Assets/Scripts/ShieldPowerUp.cs
@@ -25,6 +25,11 @@ public class ShieldPowerUp : MonoBehaviour
                     totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.ShieldDuration);
                 }
                 shield.ActivateShield(totalDuration);
+                // Report shield activation to the daily challenge system
+                if (DailyChallengeManager.Instance != null)
+                {
+                    DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.Shield);
+                }
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Scripts/SpeedBoostPowerUp.cs
+++ b/Assets/Scripts/SpeedBoostPowerUp.cs
@@ -28,6 +28,11 @@ public class SpeedBoostPowerUp : MonoBehaviour
                     totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.SpeedBoostDuration);
                 }
                 GameManager.Instance.ActivateSpeedBoost(totalDuration, speedMultiplier);
+                // Inform the DailyChallengeManager of the power-up usage
+                if (DailyChallengeManager.Instance != null)
+                {
+                    DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.SpeedBoost);
+                }
             }
             if (AudioManager.Instance != null)
             {

--- a/Assets/Tests/EditMode/DailyChallengeManagerTests.cs
+++ b/Assets/Tests/EditMode/DailyChallengeManagerTests.cs
@@ -1,0 +1,82 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests verifying generation and completion logic of <see cref="DailyChallengeManager"/>.
+/// </summary>
+public class DailyChallengeManagerTests
+{
+    [SetUp]
+    public void ClearPrefs()
+    {
+        PlayerPrefs.DeleteAll();
+    }
+
+    [Test]
+    public void GenerateChallenge_WhenPrefsMissing_CreatesNewEntry()
+    {
+        var go = new GameObject("dc");
+        var dc = go.AddComponent<DailyChallengeManager>();
+
+        Assert.IsTrue(PlayerPrefs.HasKey("DailyChallengeData"));
+        string json = PlayerPrefs.GetString("DailyChallengeData");
+        Assert.IsNotEmpty(json);
+
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void CompleteChallenge_RewardsCoins()
+    {
+        // Prepare a simple distance challenge in PlayerPrefs
+        var state = new PrivateChallengeState
+        {
+            type = DailyChallengeManager.ChallengeType.Distance,
+            target = 5,
+            progress = 0,
+            powerUp = DailyChallengeManager.PowerUpType.Magnet,
+            expires = System.DateTime.UtcNow.AddDays(1).Ticks,
+            completed = false
+        };
+        string json = JsonUtility.ToJson(state);
+        PlayerPrefs.SetString("DailyChallengeData", json);
+
+        // Game and shop instances to track coins
+        var shopObj = new GameObject("shop");
+        var shop = shopObj.AddComponent<ShopManager>();
+        shop.availableUpgrades = new ShopManager.UpgradeData[0];
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(shop, null);
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+
+        var dcObj = new GameObject("dc");
+        var dc = dcObj.AddComponent<DailyChallengeManager>();
+
+        // Force distance so challenge completes
+        var distField = typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance);
+        distField.SetValue(gm, 6f);
+
+        dc.Update();
+
+        Assert.IsTrue(PlayerPrefs.GetString("DailyChallengeData").Contains("\"completed\":true"));
+        Assert.Greater(shop.Coins, 0);
+
+        Object.DestroyImmediate(dcObj);
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(shopObj);
+    }
+
+    // Small helper struct to craft challenge JSON for tests
+    private class PrivateChallengeState
+    {
+        public DailyChallengeManager.ChallengeType type;
+        public DailyChallengeManager.PowerUpType powerUp;
+        public int target;
+        public int progress;
+        public long expires;
+        public bool completed;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DailyChallengeManager` to generate and persist daily challenges
- display daily challenge status with `DailyChallengeUI`
- report power-up usage to the challenge manager
- verify challenge generation and completion logic with unit tests

## Testing
- `npm test`