### PR TITLE
Add stage-based spawn settings

### DIFF
--- a/Assets/Scripts/HazardSpawner.cs
+++ b/Assets/Scripts/HazardSpawner.cs
@@ -1,9 +1,10 @@
 using UnityEngine;
 
 /// <summary>
-/// Creates pits and flying bat hazards as the game progresses. Spawning
+/// Creates pits and flying hazards as the game progresses. Spawning
 /// frequency increases with the player's distance. Supports object
-/// pooling for performance.
+/// pooling for performance. Stage-specific spawn weights and a
+/// difficulty multiplier are applied by <see cref="StageManager"/>.
 /// </summary>
 public class HazardSpawner : MonoBehaviour
 {
@@ -13,6 +14,19 @@ public class HazardSpawner : MonoBehaviour
     public GameObject[] zigZagPrefabs;
     public GameObject[] swoopPrefabs;
     public GameObject[] shooterPrefabs;
+    [Header("Stage Parameters")]
+    [Tooltip("Multiplier applied to spawn rate from the current stage.")]
+    public float spawnMultiplier = 1f;
+    [Tooltip("Relative chance to spawn pits.")]
+    public float pitChance = 1f;
+    [Tooltip("Relative chance to spawn bats.")]
+    public float batChance = 1f;
+    [Tooltip("Relative chance to spawn zig-zag enemies.")]
+    public float zigZagChance = 1f;
+    [Tooltip("Relative chance to spawn swooping enemies.")]
+    public float swoopChance = 1f;
+    [Tooltip("Relative chance to spawn shooter enemies.")]
+    public float shooterChance = 1f;
     public float spawnInterval = 5f;
     // Controls how the spawn interval scales with player distance.
     public AnimationCurve spawnRateCurve = AnimationCurve.Linear(0f, 1f, 100f, 2f);
@@ -80,7 +94,8 @@ public class HazardSpawner : MonoBehaviour
         if (timer <= 0f)
         {
             SpawnHazard();
-            timer = spawnInterval / difficulty;
+            float mult = Mathf.Max(0.01f, spawnMultiplier);
+            timer = spawnInterval / (difficulty * mult);
         }
     }
 
@@ -92,36 +107,55 @@ public class HazardSpawner : MonoBehaviour
     {
         var lists = new System.Collections.Generic.List<GameObject[]>();
         var heights = new System.Collections.Generic.List<float>();
+        var chance = new System.Collections.Generic.List<float>();
 
-        if (pitPrefabs != null && pitPrefabs.Length > 0)
+        if (pitPrefabs != null && pitPrefabs.Length > 0 && pitChance > 0f)
         {
             lists.Add(pitPrefabs);
             heights.Add(groundY);
+            chance.Add(pitChance);
         }
-        if (batPrefabs != null && batPrefabs.Length > 0)
+        if (batPrefabs != null && batPrefabs.Length > 0 && batChance > 0f)
         {
             lists.Add(batPrefabs);
             heights.Add(airY);
+            chance.Add(batChance);
         }
-        if (zigZagPrefabs != null && zigZagPrefabs.Length > 0)
+        if (zigZagPrefabs != null && zigZagPrefabs.Length > 0 && zigZagChance > 0f)
         {
             lists.Add(zigZagPrefabs);
             heights.Add(airY);
+            chance.Add(zigZagChance);
         }
-        if (swoopPrefabs != null && swoopPrefabs.Length > 0)
+        if (swoopPrefabs != null && swoopPrefabs.Length > 0 && swoopChance > 0f)
         {
             lists.Add(swoopPrefabs);
             heights.Add(airY);
+            chance.Add(swoopChance);
         }
-        if (shooterPrefabs != null && shooterPrefabs.Length > 0)
+        if (shooterPrefabs != null && shooterPrefabs.Length > 0 && shooterChance > 0f)
         {
             lists.Add(shooterPrefabs);
             heights.Add(airY);
+            chance.Add(shooterChance);
         }
 
         if (lists.Count == 0) return;
 
-        int groupIndex = Random.Range(0, lists.Count);
+        float total = 0f;
+        foreach (float c in chance) total += c;
+        float roll = Random.Range(0f, total);
+        int groupIndex = 0;
+        float accum = 0f;
+        for (int i = 0; i < chance.Count; i++)
+        {
+            accum += chance[i];
+            if (roll <= accum)
+            {
+                groupIndex = i;
+                break;
+            }
+        }
         GameObject[] prefabs = lists[groupIndex];
         float y = heights[groupIndex];
         GameObject prefab = prefabs[Random.Range(0, prefabs.Length)];

--- a/Assets/Scripts/ObstacleSpawner.cs
+++ b/Assets/Scripts/ObstacleSpawner.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 /// <summary>
 /// Periodically spawns ground or ceiling obstacles that the player must
 /// avoid. Spawn timing accelerates as the run progresses and objects can
-/// be pooled for efficiency.
+/// be pooled for efficiency. This class now supports stage-specific
+/// probability weights and a spawn rate multiplier supplied by
+/// <see cref="StageManager"/>.
 /// </summary>
 public class ObstacleSpawner : MonoBehaviour
 {
@@ -11,6 +13,18 @@ public class ObstacleSpawner : MonoBehaviour
     public GameObject[] ceilingObstacles;
     public GameObject[] movingPlatforms;
     public GameObject[] rotatingHazards;
+
+    [Header("Stage Parameters")]
+    [Tooltip("Multiplier applied to spawn rate from the current stage.")]
+    public float spawnMultiplier = 1f;
+    [Tooltip("Relative chance to pick ground obstacles.")]
+    public float groundChance = 1f;
+    [Tooltip("Relative chance to pick ceiling obstacles.")]
+    public float ceilingChance = 1f;
+    [Tooltip("Relative chance to pick moving platforms.")]
+    public float platformChance = 1f;
+    [Tooltip("Relative chance to pick rotating hazards.")]
+    public float rotatingChance = 1f;
 
     // Names of obstacle prefabs located under Assets/Art/Resources.
     public string[] groundObstacleNames;
@@ -96,7 +110,8 @@ public class ObstacleSpawner : MonoBehaviour
         if (timer <= 0f)
         {
             Spawn();
-            timer = spawnInterval / difficulty;
+            float mult = Mathf.Max(0.01f, spawnMultiplier);
+            timer = spawnInterval / (difficulty * mult);
         }
     }
 
@@ -108,29 +123,47 @@ public class ObstacleSpawner : MonoBehaviour
     {
         var prefabsList = new System.Collections.Generic.List<GameObject[]>();
         var yList = new System.Collections.Generic.List<float>();
-        if (groundObstacles.Length > 0)
+        var chanceList = new System.Collections.Generic.List<float>();
+        if (groundObstacles.Length > 0 && groundChance > 0f)
         {
             prefabsList.Add(groundObstacles);
             yList.Add(groundY);
+            chanceList.Add(groundChance);
         }
-        if (ceilingObstacles.Length > 0)
+        if (ceilingObstacles.Length > 0 && ceilingChance > 0f)
         {
             prefabsList.Add(ceilingObstacles);
             yList.Add(ceilingY);
+            chanceList.Add(ceilingChance);
         }
-        if (movingPlatforms.Length > 0)
+        if (movingPlatforms.Length > 0 && platformChance > 0f)
         {
             prefabsList.Add(movingPlatforms);
             yList.Add(middleY);
+            chanceList.Add(platformChance);
         }
-        if (rotatingHazards.Length > 0)
+        if (rotatingHazards.Length > 0 && rotatingChance > 0f)
         {
             prefabsList.Add(rotatingHazards);
             yList.Add(middleY);
+            chanceList.Add(rotatingChance);
         }
         if (prefabsList.Count == 0) return;
 
-        int index = Random.Range(0, prefabsList.Count);
+        float total = 0f;
+        foreach (float c in chanceList) total += c;
+        float roll = Random.Range(0f, total);
+        int index = 0;
+        float accum = 0f;
+        for (int i = 0; i < chanceList.Count; i++)
+        {
+            accum += chanceList[i];
+            if (roll <= accum)
+            {
+                index = i;
+                break;
+            }
+        }
         GameObject[] prefabs = prefabsList[index];
         float y = yList[index];
         GameObject prefab = prefabs[Random.Range(0, prefabs.Length)];

--- a/Assets/Scripts/StageDataSO.cs
+++ b/Assets/Scripts/StageDataSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// ScriptableObject wrapper around <see cref="StageManager.StageData"/> so stage
+/// configurations can be stored as assets and reused between scenes.
+/// It exposes spawn multipliers and probability weights for easy tweaking
+/// in the Unity inspector.
+/// </summary>
+[CreateAssetMenu(menuName = "CaveRunner/Stage Data", fileName = "StageData")]
+public class StageDataSO : ScriptableObject
+{
+    public StageManager.StageData stage;
+}

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -1,8 +1,9 @@
 // StageManager.cs
 // -----------------------------------------------------------------------------
 // Handles stage progression events triggered by the GameManager. When a stage
-// is unlocked it swaps the active background sprite and adjusts obstacle and
-// hazard prefab lists to increase difficulty.
+// is unlocked it swaps the active background sprite, adjusts obstacle and
+// hazard prefab lists and now applies stage-specific spawn probabilities and
+// difficulty multipliers to spawners.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -42,6 +43,34 @@ public class StageManager : MonoBehaviour
 
         [Tooltip("Shooter enemies available in this stage.")]
         public GameObject[] shooterEnemies;
+
+        [Header("Spawn Rate Multipliers")]
+        [Tooltip("Multiplier applied to obstacle spawn rate during this stage.")]
+        public float obstacleSpawnMultiplier = 1f;
+        [Tooltip("Multiplier applied to hazard spawn rate during this stage.")]
+        public float hazardSpawnMultiplier = 1f;
+
+        [Header("Obstacle Spawn Probabilities")]
+        [Tooltip("Relative chance to spawn ground obstacles.")]
+        public float groundObstacleChance = 1f;
+        [Tooltip("Relative chance to spawn ceiling obstacles.")]
+        public float ceilingObstacleChance = 1f;
+        [Tooltip("Relative chance to spawn moving platforms.")]
+        public float movingPlatformChance = 1f;
+        [Tooltip("Relative chance to spawn rotating hazards.")]
+        public float rotatingHazardChance = 1f;
+
+        [Header("Hazard Spawn Probabilities")]
+        [Tooltip("Relative chance to spawn pits.")]
+        public float pitChance = 1f;
+        [Tooltip("Relative chance to spawn bats.")]
+        public float batChance = 1f;
+        [Tooltip("Relative chance to spawn zig-zag enemies.")]
+        public float zigZagChance = 1f;
+        [Tooltip("Relative chance to spawn swooping enemies.")]
+        public float swoopChance = 1f;
+        [Tooltip("Relative chance to spawn shooter enemies.")]
+        public float shooterChance = 1f;
     }
 
     [Tooltip("Background component whose spriteName will change per stage.")]
@@ -52,7 +81,7 @@ public class StageManager : MonoBehaviour
     public HazardSpawner hazardSpawner;
 
     [Tooltip("Ordered list of data for each stage.")]
-    public StageData[] stages;
+    public StageDataSO[] stages;
 
     void Awake()
     {
@@ -91,7 +120,12 @@ public class StageManager : MonoBehaviour
             return; // invalid index or no data
         }
 
-        StageData data = stages[stageIndex];
+        StageDataSO asset = stages[stageIndex];
+        if (asset == null)
+        {
+            return; // asset missing
+        }
+        StageData data = asset.stage;
 
         // Swap the scrolling background sprite if a name was provided.
         if (parallaxBackground != null && !string.IsNullOrEmpty(data.backgroundSprite))
@@ -108,16 +142,21 @@ public class StageManager : MonoBehaviour
             }
         }
 
-        // Update obstacle prefabs so newly spawned objects reflect the stage.
+        // Update obstacle prefabs and apply spawn settings for this stage.
         if (obstacleSpawner != null)
         {
             obstacleSpawner.groundObstacles = data.groundObstacles;
             obstacleSpawner.ceilingObstacles = data.ceilingObstacles;
             obstacleSpawner.movingPlatforms = data.movingPlatforms;
             obstacleSpawner.rotatingHazards = data.rotatingHazards;
+            obstacleSpawner.spawnMultiplier = data.obstacleSpawnMultiplier;
+            obstacleSpawner.groundChance = data.groundObstacleChance;
+            obstacleSpawner.ceilingChance = data.ceilingObstacleChance;
+            obstacleSpawner.platformChance = data.movingPlatformChance;
+            obstacleSpawner.rotatingChance = data.rotatingHazardChance;
         }
 
-        // Update hazard prefabs so newly spawned hazards match the stage.
+        // Update hazard prefabs and spawn parameters for this stage.
         if (hazardSpawner != null)
         {
             hazardSpawner.pitPrefabs = data.pits;
@@ -125,6 +164,12 @@ public class StageManager : MonoBehaviour
             hazardSpawner.zigZagPrefabs = data.zigZagEnemies;
             hazardSpawner.swoopPrefabs = data.swoopingEnemies;
             hazardSpawner.shooterPrefabs = data.shooterEnemies;
+            hazardSpawner.spawnMultiplier = data.hazardSpawnMultiplier;
+            hazardSpawner.pitChance = data.pitChance;
+            hazardSpawner.batChance = data.batChance;
+            hazardSpawner.zigZagChance = data.zigZagChance;
+            hazardSpawner.swoopChance = data.swoopChance;
+            hazardSpawner.shooterChance = data.shooterChance;
         }
     }
 }

--- a/Assets/Tests/EditMode/StageManagerTests.cs
+++ b/Assets/Tests/EditMode/StageManagerTests.cs
@@ -33,7 +33,8 @@ public class StageManagerTests
 
         // Provide simple prefabs for stage data
         var dummy = new GameObject("prefab");
-        var stage = new StageManager.StageData
+        var stageAsset = ScriptableObject.CreateInstance<StageDataSO>();
+        stageAsset.stage = new StageManager.StageData
         {
             backgroundSprite = "stageA",
             groundObstacles = new[] { dummy },
@@ -41,16 +42,21 @@ public class StageManagerTests
             movingPlatforms = new GameObject[0],
             rotatingHazards = new GameObject[0],
             pits = new GameObject[0],
-            bats = new GameObject[0]
+            bats = new GameObject[0],
+            obstacleSpawnMultiplier = 2f,
+            hazardSpawnMultiplier = 0.5f
         };
-        sm.stages = new[] { stage };
+        sm.stages = new[] { stageAsset };
 
         sm.ApplyStage(0);
 
         Assert.AreEqual("stageA", bg.spriteName);
         Assert.AreSame(dummy, obstacleSpawner.groundObstacles[0]);
+        Assert.AreEqual(2f, obstacleSpawner.spawnMultiplier);
+        Assert.AreEqual(0.5f, hazardSpawner.spawnMultiplier);
 
         Object.DestroyImmediate(dummy);
+        Object.DestroyImmediate(stageAsset);
         Object.DestroyImmediate(gmObj);
         Object.DestroyImmediate(bgObj);
         Object.DestroyImmediate(obsObj);
@@ -80,10 +86,11 @@ public class StageManagerTests
         sm.parallaxBackground = bg;
         sm.obstacleSpawner = obstacleSpawner;
         sm.hazardSpawner = hazardSpawner;
-        sm.stages = new[] {
-            new StageManager.StageData { backgroundSprite = "start" },
-            new StageManager.StageData { backgroundSprite = "next" }
-        };
+        var start = ScriptableObject.CreateInstance<StageDataSO>();
+        start.stage = new StageManager.StageData { backgroundSprite = "start" };
+        var next = ScriptableObject.CreateInstance<StageDataSO>();
+        next.stage = new StageManager.StageData { backgroundSprite = "next" };
+        sm.stages = new[] { start, next };
 
         gm.StartGame();
         // Initial stage should apply index 0


### PR DESCRIPTION
## Summary
- expand `StageManager.StageData` with probability and multiplier options
- allow spawners to use weighted random selection and stage multipliers
- create `StageDataSO` ScriptableObject for easier editor tweaking
- adjust StageManager and tests to use scriptable stage data

## Testing
- `npm test`