### PR TITLE
Add stacked coin bonus and indicator

### DIFF
--- a/Assets/Scripts/CoinBonusIndicator.cs
+++ b/Assets/Scripts/CoinBonusIndicator.cs
@@ -1,0 +1,37 @@
+// CoinBonusIndicator.cs
+// -----------------------------------------------------------------------------
+// UI component that displays the remaining duration of the coin bonus effect
+// on screen. The text element is hidden whenever no bonus is active. Designed
+// to be attached to a UI GameObject with a Text child.
+// -----------------------------------------------------------------------------
+
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Updates a UI <see cref="Text"/> to show the current coin bonus multiplier
+/// and countdown. The label is automatically hidden when the bonus expires.
+/// </summary>
+public class CoinBonusIndicator : MonoBehaviour
+{
+    [Tooltip("UI text displaying multiplier and remaining seconds.")]
+    public Text timerLabel;
+
+    void Update()
+    {
+        if (timerLabel == null) return;
+
+        GameManager gm = GameManager.Instance;
+        if (gm != null && gm.GetCoinBonusTimeRemaining() > 0f)
+        {
+            float time = gm.GetCoinBonusTimeRemaining();
+            timerLabel.text = $"x{gm.GetCoinBonusMultiplier()} {time:F1}s";
+            if (!timerLabel.gameObject.activeSelf)
+                timerLabel.gameObject.SetActive(true);
+        }
+        else if (timerLabel.gameObject.activeSelf)
+        {
+            timerLabel.gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/CoinBonusPowerUp.cs
+++ b/Assets/Scripts/CoinBonusPowerUp.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+/// <summary>
+/// Grants a temporary multiplier to all coin pickups when collected. The
+/// duration can be extended via the <see cref="UpgradeType.CoinBonusDuration"/>
+/// upgrade in the shop. Multiple pickups stack their remaining time and use
+/// the highest multiplier.
+/// </summary>
+public class CoinBonusPowerUp : MonoBehaviour
+{
+    [Tooltip("Seconds the coin bonus remains active after pickup.")]
+    public float duration = 5f;
+
+    [Tooltip("Multiplier applied to coins while active.")]
+    public float multiplier = 2f;
+
+    public AudioClip collectClip;
+
+    // Triggered when the player touches the power-up.
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (!other.CompareTag("Player"))
+            return;
+
+        // Activate the bonus using the GameManager singleton.
+        if (GameManager.Instance != null)
+        {
+            float totalDuration = duration;
+            if (ShopManager.Instance != null)
+            {
+                totalDuration += ShopManager.Instance.GetUpgradeEffect(UpgradeType.CoinBonusDuration);
+            }
+            GameManager.Instance.ActivateCoinBonus(totalDuration, multiplier);
+            // Report usage for daily challenges if enabled.
+            if (DailyChallengeManager.Instance != null)
+            {
+                DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.CoinBonus);
+            }
+        }
+        // Play a pickup sound if configured.
+        if (AudioManager.Instance != null)
+        {
+            AudioManager.Instance.PlaySound(collectClip);
+        }
+        // Return to pool if pooled, otherwise destroy.
+        PooledObject po = GetComponent<PooledObject>();
+        if (po != null && po.Pool != null)
+        {
+            po.Pool.ReturnObject(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/DailyChallengeManager.cs
+++ b/Assets/Scripts/DailyChallengeManager.cs
@@ -14,7 +14,7 @@ public class DailyChallengeManager : MonoBehaviour
     public enum ChallengeType { Distance, Coins, PowerUpUse }
 
     /// <summary>Supported power-up identifiers for power-up challenges.</summary>
-    public enum PowerUpType { Magnet, SpeedBoost, Shield, GravityFlip, SlowMotion }
+    public enum PowerUpType { Magnet, SpeedBoost, Shield, GravityFlip, SlowMotion, CoinBonus }
 
     [Serializable]
     private class ChallengeState

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -13,7 +13,10 @@ using System.Collections;
 /// increases, optional feedback such as camera shake, particles and a
 /// pitched sound effect is played. Recent revisions add slow motion
 /// support, stage-specific speed modifiers and the ability to start a run
-/// with random power-ups.
+/// with random power-ups. This revision also introduces a temporary coin
+/// bonus effect that multiplies coin pickups when active. The effect now
+/// stacks when additional power-ups are collected and exposes helper
+/// methods so UI elements can display the remaining time.
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -39,6 +42,10 @@ public class GameManager : MonoBehaviour
     private bool gravityFlipped;              // true while gravity is inverted
     private float coinComboTimer;             // countdown for maintaining a coin combo
     private int coinComboMultiplier = 1;      // current coin multiplier from the combo
+
+    // Coin bonus power-up variables
+    private float coinBonusTimer;             // remaining time coins are multiplied
+    private float coinBonusMultiplier = 1f;   // active multiplier applied to coin pickups
 
     private float slowMotionTimer;            // time remaining on slow motion
     private float slowMotionScale = 1f;       // scale value applied during slow motion
@@ -121,6 +128,8 @@ public class GameManager : MonoBehaviour
         currentStage = 0;
         coinComboTimer = 0f;
         coinComboMultiplier = 1;
+        coinBonusTimer = 0f;
+        coinBonusMultiplier = 1f;
 
         if (SteamManager.Instance != null)
         {
@@ -178,6 +187,16 @@ public class GameManager : MonoBehaviour
             {
                 coinComboMultiplier = 1;
                 UpdateMultiplierLabel();
+            }
+        }
+
+        // Count down coin bonus timer and reset when expired
+        if (coinBonusTimer > 0f)
+        {
+            coinBonusTimer -= Time.deltaTime;
+            if (coinBonusTimer <= 0f)
+            {
+                coinBonusMultiplier = 1f;
             }
         }
 
@@ -243,6 +262,8 @@ public class GameManager : MonoBehaviour
             gravityFlipped = false;
             gravityFlipTimer = 0f;
         }
+        coinBonusMultiplier = 1f;
+        coinBonusTimer = 0f;
         int finalScore = Mathf.FloorToInt(distance);
         int highScore = SaveGameManager.Instance.HighScore;
 
@@ -328,6 +349,8 @@ public class GameManager : MonoBehaviour
         currentStage = 0;
         coinComboTimer = 0f;
         coinComboMultiplier = 1;
+        coinBonusTimer = 0f;
+        coinBonusMultiplier = 1f;
 
         stageSpeedMultiplier = 1f;
         slowMotionTimer = 0f;
@@ -389,6 +412,41 @@ public class GameManager : MonoBehaviour
     {
         speedMultiplier = multiplier;
         speedBoostTimer = duration;
+    }
+
+    /// <summary>
+    /// Temporarily increases the value of collected coins.
+    /// </summary>
+    /// <param name="duration">Seconds the bonus remains active.</param>
+    /// <param name="multiplier">Multiplier applied to each coin pickup.</param>
+    public void ActivateCoinBonus(float duration, float multiplier)
+    {
+        if (duration <= 0f)
+            throw new ArgumentException("duration must be positive", nameof(duration));
+        if (multiplier < 1f)
+            throw new ArgumentOutOfRangeException(nameof(multiplier), "multiplier must be >= 1");
+
+        // Extend any active bonus so multiple pickups stack
+        coinBonusTimer += duration;
+        // Use whichever multiplier is higher to encourage combining power-ups
+        coinBonusMultiplier = Mathf.Max(coinBonusMultiplier, multiplier);
+    }
+
+    /// <summary>
+    /// Remaining seconds on the current coin bonus effect. Returns zero when
+    /// no bonus is active.
+    /// </summary>
+    public float GetCoinBonusTimeRemaining()
+    {
+        return Mathf.Max(0f, coinBonusTimer);
+    }
+
+    /// <summary>
+    /// Current multiplier applied to coin pickups from the coin bonus.
+    /// </summary>
+    public float GetCoinBonusMultiplier()
+    {
+        return coinBonusMultiplier;
     }
 
     /// <summary>
@@ -497,8 +555,8 @@ public class GameManager : MonoBehaviour
             bonus = ShopManager.Instance.GetUpgradeEffect(UpgradeType.CoinMultiplier);
         }
 
-        // Final value after combo and upgrade bonuses are applied.
-        coins += Mathf.RoundToInt((amount + bonus) * coinComboMultiplier);
+        // Final value after all bonuses are applied including temporary coin bonus.
+        coins += Mathf.RoundToInt((amount + bonus) * coinComboMultiplier * coinBonusMultiplier);
         UpdateCoinLabel();
         UpdateMultiplierLabel();
     }

--- a/Assets/Scripts/UpgradeType.cs
+++ b/Assets/Scripts/UpgradeType.cs
@@ -24,5 +24,8 @@ public enum UpgradeType
     BaseSpeedBonus = 4,
 
     /// <summary>Number of random power-ups granted when starting a new run.</summary>
-    StartingPowerUp = 5
+    StartingPowerUp = 5,
+
+    /// <summary>Extends the duration of the coin bonus power-up.</summary>
+    CoinBonusDuration = 6
 }

--- a/Assets/Tests/EditMode/CoinBonusIndicatorTests.cs
+++ b/Assets/Tests/EditMode/CoinBonusIndicatorTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Tests for the CoinBonusIndicator component ensuring it shows and hides
+/// based on the GameManager's coin bonus state.
+/// </summary>
+public class CoinBonusIndicatorTests
+{
+    [Test]
+    public void Update_ShowsAndHidesLabel()
+    {
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+
+        var uiObj = new GameObject("ui");
+        var text = uiObj.AddComponent<Text>();
+        var ind = uiObj.AddComponent<CoinBonusIndicator>();
+        ind.timerLabel = text;
+
+        // Initially inactive
+        ind.Update();
+        Assert.IsFalse(text.gameObject.activeSelf);
+
+        gm.ActivateCoinBonus(1f, 2f);
+        ind.Update();
+        Assert.IsTrue(text.gameObject.activeSelf);
+
+        // Expire the bonus
+        typeof(GameManager).GetField("coinBonusTimer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).SetValue(gm, 0f);
+        ind.Update();
+        Assert.IsFalse(text.gameObject.activeSelf);
+
+        Object.DestroyImmediate(uiObj);
+        Object.DestroyImmediate(gmObj);
+    }
+}

--- a/Assets/Tests/EditMode/CoinBonusPowerUpTests.cs
+++ b/Assets/Tests/EditMode/CoinBonusPowerUpTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests for the CoinBonusPowerUp component ensuring the coin bonus duration
+/// includes upgrade effects.
+/// </summary>
+public class CoinBonusPowerUpTests
+{
+    [Test]
+    public void CoinBonusPowerUp_UsesUpgradeEffect()
+    {
+        System.IO.File.Delete(System.IO.Path.Combine(
+            Application.persistentDataPath, "savegame.json"));
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+        var data = new ShopManager.UpgradeData { type = UpgradeType.CoinBonusDuration, cost = 1, effect = 1f };
+
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (System.Collections.Generic.Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.CoinBonusDuration] = 1;
+        dictField.SetValue(sm, levels);
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+
+        var player = new GameObject("player");
+        player.tag = "Player";
+        var playerCol = player.AddComponent<BoxCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var cb = powerObj.AddComponent<CoinBonusPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+        cb.duration = 2f;
+        cb.multiplier = 2f;
+
+        cb.OnTriggerEnter2D(playerCol);
+
+        var timerField = typeof(GameManager).GetField("coinBonusTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(gm);
+
+        Assert.AreEqual(3f, timer);
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(shopObj);
+        Object.DestroyImmediate(saveObj);
+    }
+}

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -119,6 +119,69 @@ public class GameManagerTests
     }
 
     [Test]
+    public void ActivateCoinBonus_MultipliesCoins()
+    {
+        var go = new GameObject("gm");
+        var gm = go.AddComponent<GameManager>();
+        gm.StartGame();
+
+        gm.ActivateCoinBonus(1f, 2f);
+        gm.AddCoins(1);
+        Assert.AreEqual(2, gm.GetCoins());
+
+        typeof(GameManager).GetField("coinBonusTimer", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, 0f);
+        gm.Update();
+        gm.AddCoins(1);
+        Assert.AreEqual(3, gm.GetCoins());
+
+        Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// Verifies that coin bonus pickups stack their durations and keep the
+    /// highest multiplier.
+    /// </summary>
+    [Test]
+    public void ActivateCoinBonus_StacksDurationAndMultiplier()
+    {
+        var go = new GameObject("gm");
+        var gm = go.AddComponent<GameManager>();
+        gm.StartGame();
+
+        gm.ActivateCoinBonus(1f, 2f);
+        gm.ActivateCoinBonus(0.5f, 3f);
+
+        var timerField = typeof(GameManager).GetField("coinBonusTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        var multField = typeof(GameManager).GetField("coinBonusMultiplier", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        float timer = (float)timerField.GetValue(gm);
+        float multiplier = (float)multField.GetValue(gm);
+
+        Assert.AreEqual(1.5f, timer);
+        Assert.AreEqual(3f, multiplier);
+
+        Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// Ensures the public getters return the current bonus values for UI.
+    /// </summary>
+    [Test]
+    public void GetCoinBonusMethods_ReturnCurrentValues()
+    {
+        var go = new GameObject("gm");
+        var gm = go.AddComponent<GameManager>();
+        gm.StartGame();
+
+        gm.ActivateCoinBonus(1f, 2f);
+
+        Assert.AreEqual(1f, gm.GetCoinBonusTimeRemaining());
+        Assert.AreEqual(2f, gm.GetCoinBonusMultiplier());
+
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
     public void ActivateSlowMotion_ChangesTimeScale()
     {
         var go = new GameObject("gm");

--- a/README.md
+++ b/README.md
@@ -29,15 +29,18 @@ Key files include:
    - **Coin Combo** increases coin value when you grab coins quickly.
    - `PowerUpSpawner` spawns temporary power-up items.
    - `MagnetPowerUp` grants a short-lived coin magnet effect when collected.
-   - `SpeedBoostPowerUp` temporarily increases the player's speed.
-   - `CoinMagnet` attaches to the player and pulls coins in while the effect is active.
+  - `SpeedBoostPowerUp` temporarily increases the player's speed.
+  - `CoinBonusPowerUp` multiplies coin pickups for a short time. Durations
+    stack when multiple are collected and an optional UI label can display the
+    remaining time.
+  - `CoinMagnet` attaches to the player and pulls coins in while the effect is active.
    - `CameraFollow` keeps the camera tracking the player.
    - `ParallaxBackground` scrolls looping background sprites.
    - `SteamManager` initializes the Steamworks API and saves high scores to the cloud.
     - `WorkshopManager` uploads and downloads level or skin packs from the Steam Workshop.
     - `ObjectPool` provides reusable objects for the spawners.
     - `AnalyticsManager` logs run data locally and can post it to a remote URL you provide.
-   - `ShopManager` persists coins and upgrades via `SaveGameManager` so players can buy bonuses between runs. Upgrades currently extend power-up durations (magnet, speed boost, shield) and award extra coins per pickup.
+   - `ShopManager` persists coins and upgrades via `SaveGameManager` so players can buy bonuses between runs. Upgrades extend power-up durations (magnet, speed boost, shield, coin bonus) and award extra coins per pickup.
 4. Add prefabs for your player, obstacles, hazards, and coins, then assign them in the inspector. Link the coin label and combo label fields of `GameManager` to UI Text elements.
 5. Create a GameObject with the `ShopManager` script so coins and upgrades persist between runs. `SaveGameManager` is automatically created by `GameManager`, so no setup is required for the save file. Add a shop panel and assign it to `UIManager.shopPanel`.
 6. Tag any obstacle or hazard prefab with **Obstacle** or **Hazard** so collisions trigger a restart. Tag coin prefabs with **Coin** so they can be collected.

--- a/docs/GameMechanics.md
+++ b/docs/GameMechanics.md
@@ -12,6 +12,8 @@ This document summarizes the core gameplay mechanics for **Cave-Runner** and how
 - **Magnet** – Attracts coins within a radius for a limited time.
 - **Speed Boost** – Temporarily increases player speed.
 - **Shield** – Absorbs one obstacle or hazard hit before breaking.
+- **Coin Bonus** – Temporarily multiplies the value of collected coins. Multiple
+  bonuses stack their remaining time and a UI indicator can show the countdown.
 
 ## Scoring
 - Distance traveled increments continuously while alive.


### PR DESCRIPTION
## Summary
- stack coin bonus activations
- expose helpers for UI elements
- add CoinBonusIndicator for showing remaining time
- test stacking and new indicator
- document stacking behavior in README and GameMechanics

## Testing
- `npm test`