### PR TITLE
Add CI workflow and WorkshopManager tests

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -1,0 +1,31 @@
+name: Unity EditMode Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Run EditMode tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Unity
+        uses: game-ci/unity-setup@v2
+        with:
+          unityVersion: 2022.3.0f1
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2
+        with:
+          testMode: EditMode
+          artifactsPath: TestResults
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: TestResults
+          path: TestResults
+

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -1,3 +1,15 @@
+#region AudioManager Overview
+/*
+ * Provides global music and sound effect control. Attach this component to a
+ * GameObject in the starting scene and access <see cref="AudioManager.Instance"/>
+ * to play effects:
+ *
+ *   AudioManager.Instance.PlaySound("Jump");
+ *
+ * Volume levels are saved via <see cref="SaveGameManager"/> so they persist
+ * between sessions. The manager persists across scene loads.
+ */
+#endregion
 using UnityEngine;
 
 /// <summary>

--- a/Assets/Scripts/WorkshopManager.cs
+++ b/Assets/Scripts/WorkshopManager.cs
@@ -1,3 +1,21 @@
+#region WorkshopManager Overview
+/*
+ * Provides convenience wrappers around the Steamworks UGC API so the game can
+ * download and upload community content. Usage typically looks like:
+ *
+ *   // After SteamManager has initialized Steamworks
+ *   WorkshopManager.Instance.DownloadSubscribedItems(paths =>
+ *   {
+ *       foreach (var dir in paths)
+ *       {
+ *           // Load assets from each directory
+ *       }
+ *   });
+ *
+ * Call <see cref="UploadItem"/> to publish new content. These features require
+ * the Steamworks.NET plugin and only function on standalone platforms.
+ */
+#endregion
 using UnityEngine;
 #if UNITY_STANDALONE
 using Steamworks;

--- a/Assets/Tests/EditMode/WorkshopManagerTests.cs
+++ b/Assets/Tests/EditMode/WorkshopManagerTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+using System.Collections.Generic;
+
+/// <summary>
+/// Unit tests covering early exit behaviour of <see cref="WorkshopManager"/>.
+/// Steamworks calls are not invoked; instead the private initialization flag is
+/// toggled via reflection to simulate different states.
+/// </summary>
+public class WorkshopManagerTests
+{
+#if UNITY_STANDALONE
+    /// <summary>
+    /// When Steamworks is unavailable the download method should immediately
+    /// return an empty list via the callback.
+    /// </summary>
+    [Test]
+    public void DownloadSubscribedItems_NotInitialized_ReturnsEmpty()
+    {
+        var go = new GameObject("wm");
+        var wm = go.AddComponent<WorkshopManager>();
+        FieldInfo init = typeof(WorkshopManager).GetField("initialized", BindingFlags.NonPublic | BindingFlags.Instance);
+        init.SetValue(wm, false);
+
+        List<string> result = null;
+        wm.DownloadSubscribedItems(paths => result = paths);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+        Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// UploadItem should report failure through the callback when Steamworks
+    /// has not been initialized.
+    /// </summary>
+    [Test]
+    public void UploadItem_NotInitialized_ReturnsFalse()
+    {
+        var go = new GameObject("wm");
+        var wm = go.AddComponent<WorkshopManager>();
+        FieldInfo init = typeof(WorkshopManager).GetField("initialized", BindingFlags.NonPublic | BindingFlags.Instance);
+        init.SetValue(wm, false);
+
+        bool success = true;
+        wm.UploadItem("folder", "preview.png", "title", "desc", s => success = s);
+
+        Assert.IsFalse(success);
+        Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// The singleton instance should be assigned on Awake and cleared when the
+    /// component is destroyed.
+    /// </summary>
+    [Test]
+    public void SingletonLifecycle_AwakeAndDestroy()
+    {
+        var go = new GameObject("wm");
+        var wm = go.AddComponent<WorkshopManager>();
+        Assert.AreEqual(wm, WorkshopManager.Instance);
+        Object.DestroyImmediate(go);
+        Assert.IsNull(WorkshopManager.Instance);
+    }
+#else
+    [Test]
+    public void WorkshopManager_IgnoredOnNonStandalone()
+    {
+        Assert.Pass("Steamworks not available");
+    }
+#endif
+}

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -17,6 +17,13 @@ Unity -batchmode -projectPath <path> -runTests -testPlatform editmode \
 
 The above command writes an XML report and log file that can be archived by your CI system.
 
+## Continuous Integration
+EditMode tests are automatically executed on every push and pull request using
+GitHub Actions. The workflow defined at `.github/workflows/unity-tests.yml`
+installs Unity via the GameCI actions, runs the command shown above and uploads
+the generated `TestResults` folder as an artifact. No manual steps are required
+to verify that new commits keep the tests passing.
+
 ## What Is Covered?
 - Jump and slide buffering to ensure responsive controls.
 - Enhanced gravity logic for snappy jumps.


### PR DESCRIPTION
## Summary
- automate EditMode tests via GitHub Actions
- document CI process in Testing.md
- document AudioManager and WorkshopManager usage
- add unit tests for WorkshopManager

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -logFile test.log -quit` *(fails: command not found)*