### PR TITLE
Add Unity build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,12 @@
 # Unity Build Pipeline
 #
-# Builds for Windows, macOS and Linux using GameCI actions. Each job runs
-# EditMode tests exactly as described in docs/Testing.md before invoking the
-# builder. Artifacts for each platform are uploaded from `build/<platform>`.
+# This workflow uses GameCI actions to build the project for Windows, macOS,
+# and Linux. Before each build the EditMode tests described in
+# `docs/Testing.md` are executed. Artifacts for each platform are downloaded
+# from the following directories:
+#   Windows -> `build/StandaloneWindows64`
+#   macOS   -> `build/StandaloneOSX`
+#   Linux   -> `build/StandaloneLinux64`
 
 name: Unity Builds
 
@@ -13,112 +17,56 @@ on:
     branches: [ main ]
 
 jobs:
-  build-windows:
-    name: Build Windows
+  build:
+    # A single job that runs for each platform in a matrix
+    name: Build ${{ matrix.platform }}
     runs-on: ubuntu-latest
-    steps:
-      # Checkout the repository so Unity has access to the project files
-      - uses: actions/checkout@v3
-      # Set up the requested Unity version
-      - name: Set up Unity
-        uses: game-ci/unity-setup@v2
-        with:
-          unityVersion: 2022.3.0f1
-      # Run EditMode tests before building to ensure the project is stable
-      - name: Run tests
-        uses: game-ci/unity-test-runner@v2
-        with:
-          testMode: EditMode
-          artifactsPath: TestResults
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      # Store the test results as a build artifact
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: WindowsTestResults
-          path: TestResults
-      # Build the game for Windows
-      - name: Build project
-        uses: game-ci/unity-builder@v2
-        with:
-          targetPlatform: StandaloneWindows64
-          buildsPath: build
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      # Upload the generated executable located under `build/StandaloneWindows64`
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: WindowsBuild
-          path: build/StandaloneWindows64
+    strategy:
+      matrix:
+        platform:
+          - StandaloneWindows64
+          - StandaloneOSX
+          - StandaloneLinux64
 
-  build-macos:
-    name: Build macOS
-    runs-on: ubuntu-latest
     steps:
+      # Checkout the repository so Unity can access the project files
       - uses: actions/checkout@v3
-      - name: Set up Unity
-        uses: game-ci/unity-setup@v2
-        with:
-          unityVersion: 2022.3.0f1
-      - name: Run tests
-        uses: game-ci/unity-test-runner@v2
-        with:
-          testMode: EditMode
-          artifactsPath: TestResults
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: macOSTestResults
-          path: TestResults
-      - name: Build project
-        uses: game-ci/unity-builder@v2
-        with:
-          targetPlatform: StandaloneOSX
-          buildsPath: build
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      # macOS builds are placed under `build/StandaloneOSX` as a zipped .app bundle
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: macOSBuild
-          path: build/StandaloneOSX
 
-  build-linux:
-    name: Build Linux
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+      # Install the requested Unity version on the runner
       - name: Set up Unity
         uses: game-ci/unity-setup@v2
         with:
           unityVersion: 2022.3.0f1
-      - name: Run tests
+
+      # Run EditMode tests in the same manner as documented in docs/Testing.md
+      - name: Run EditMode tests
         uses: game-ci/unity-test-runner@v2
         with:
           testMode: EditMode
           artifactsPath: TestResults
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+      # Upload the XML and log results from the test run
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:
-          name: LinuxTestResults
+          name: TestResults-${{ matrix.platform }}
           path: TestResults
+
+      # Build the project for the platform specified by the matrix entry
       - name: Build project
         uses: game-ci/unity-builder@v2
         with:
-          targetPlatform: StandaloneLinux64
+          targetPlatform: ${{ matrix.platform }}
           buildsPath: build
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      # Linux build artifacts are found in `build/StandaloneLinux64`
+
+      # Publish the built files so they can be downloaded from the workflow
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:
-          name: LinuxBuild
-          path: build/StandaloneLinux64
+          name: Build-${{ matrix.platform }}
+          path: build/${{ matrix.platform }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
 # Unity Build Pipeline
 #
-# Uses GameCI actions to create standalone builds for Windows, macOS and Linux.
-# A preceding test job mirrors the steps from docs/Testing.md to ensure
-# EditMode tests pass before building. Build artifacts are zipped under
-# `build/<platform>` and uploaded for each job.
+# Builds for Windows, macOS and Linux using GameCI actions. Each job runs
+# EditMode tests exactly as described in docs/Testing.md before invoking the
+# builder. Artifacts for each platform are uploaded from `build/<platform>`.
 
 name: Unity Builds
 
@@ -14,13 +13,51 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-    name: Run EditMode tests
+  build-windows:
+    name: Build Windows
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        # Needed so the runner has the project files
+      # Checkout the repository so Unity has access to the project files
+      - uses: actions/checkout@v3
+      # Set up the requested Unity version
+      - name: Set up Unity
+        uses: game-ci/unity-setup@v2
+        with:
+          unityVersion: 2022.3.0f1
+      # Run EditMode tests before building to ensure the project is stable
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2
+        with:
+          testMode: EditMode
+          artifactsPath: TestResults
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      # Store the test results as a build artifact
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: WindowsTestResults
+          path: TestResults
+      # Build the game for Windows
+      - name: Build project
+        uses: game-ci/unity-builder@v2
+        with:
+          targetPlatform: StandaloneWindows64
+          buildsPath: build
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      # Upload the generated executable located under `build/StandaloneWindows64`
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: WindowsBuild
+          path: build/StandaloneWindows64
+
+  build-macos:
+    name: Build macOS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Set up Unity
         uses: game-ci/unity-setup@v2
         with:
@@ -35,46 +72,8 @@ jobs:
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:
-          name: TestResults
+          name: macOSTestResults
           path: TestResults
-          # The XML report and logs land here
-
-  build-windows:
-    name: Build Windows
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Unity
-        uses: game-ci/unity-setup@v2
-        with:
-          unityVersion: 2022.3.0f1
-      - name: Build project
-        uses: game-ci/unity-builder@v2
-        with:
-          targetPlatform: StandaloneWindows64
-          buildsPath: build
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: WindowsBuild
-          path: build/StandaloneWindows64
-          # Executable and data files stored in this folder
-
-  build-macos:
-    name: Build macOS
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Unity
-        uses: game-ci/unity-setup@v2
-        with:
-          unityVersion: 2022.3.0f1
       - name: Build project
         uses: game-ci/unity-builder@v2
         with:
@@ -82,24 +81,34 @@ jobs:
           buildsPath: build
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      # macOS builds are placed under `build/StandaloneOSX` as a zipped .app bundle
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:
           name: macOSBuild
           path: build/StandaloneOSX
-          # macOS .app bundle zipped in this directory
 
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest
-    needs: test
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Set up Unity
         uses: game-ci/unity-setup@v2
         with:
           unityVersion: 2022.3.0f1
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2
+        with:
+          testMode: EditMode
+          artifactsPath: TestResults
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: LinuxTestResults
+          path: TestResults
       - name: Build project
         uses: game-ci/unity-builder@v2
         with:
@@ -107,9 +116,9 @@ jobs:
           buildsPath: build
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      # Linux build artifacts are found in `build/StandaloneLinux64`
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:
           name: LinuxBuild
           path: build/StandaloneLinux64
-          # Linux build files zipped under this folder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,115 @@
+# Unity Build Pipeline
+#
+# Uses GameCI actions to create standalone builds for Windows, macOS and Linux.
+# A preceding test job mirrors the steps from docs/Testing.md to ensure
+# EditMode tests pass before building. Build artifacts are zipped under
+# `build/<platform>` and uploaded for each job.
+
+name: Unity Builds
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Run EditMode tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        # Needed so the runner has the project files
+      - name: Set up Unity
+        uses: game-ci/unity-setup@v2
+        with:
+          unityVersion: 2022.3.0f1
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2
+        with:
+          testMode: EditMode
+          artifactsPath: TestResults
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: TestResults
+          path: TestResults
+          # The XML report and logs land here
+
+  build-windows:
+    name: Build Windows
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Unity
+        uses: game-ci/unity-setup@v2
+        with:
+          unityVersion: 2022.3.0f1
+      - name: Build project
+        uses: game-ci/unity-builder@v2
+        with:
+          targetPlatform: StandaloneWindows64
+          buildsPath: build
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: WindowsBuild
+          path: build/StandaloneWindows64
+          # Executable and data files stored in this folder
+
+  build-macos:
+    name: Build macOS
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Unity
+        uses: game-ci/unity-setup@v2
+        with:
+          unityVersion: 2022.3.0f1
+      - name: Build project
+        uses: game-ci/unity-builder@v2
+        with:
+          targetPlatform: StandaloneOSX
+          buildsPath: build
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: macOSBuild
+          path: build/StandaloneOSX
+          # macOS .app bundle zipped in this directory
+
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Unity
+        uses: game-ci/unity-setup@v2
+        with:
+          unityVersion: 2022.3.0f1
+      - name: Build project
+        uses: game-ci/unity-builder@v2
+        with:
+          targetPlatform: StandaloneLinux64
+          buildsPath: build
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: LinuxBuild
+          path: build/StandaloneLinux64
+          # Linux build files zipped under this folder


### PR DESCRIPTION
## Summary
- add CI workflow to build for Windows, macOS and Linux after running tests

## Testing
- `npm test`