### PR TITLE
Add REST leaderboard with fallback

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -312,6 +312,11 @@ public class GameManager : MonoBehaviour
             // Submit the score to the Steam leaderboard
             SteamManager.Instance.UploadScore(finalScore);
         }
+        else if (LeaderboardClient.Instance != null)
+        {
+            // Non-Steam builds post to the HTTP leaderboard instead
+            StartCoroutine(LeaderboardClient.Instance.UploadScore(finalScore));
+        }
 
         // Persist run coins so they can be spent in the shop
         if (ShopManager.Instance != null)

--- a/Assets/Scripts/LeaderboardClient.cs
+++ b/Assets/Scripts/LeaderboardClient.cs
@@ -1,0 +1,167 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// Client for a simple REST-based leaderboard service used when Steamworks
+/// is unavailable. The service exposes two endpoints:
+/// <code>/scores</code> (GET) returns a JSON array of score objects and
+/// <code>/scores</code> (POST) accepts a single score entry. Responses use
+/// the format:
+/// <pre>{"name":"Player","score":123}</pre>
+/// All requests are sent using <see cref="UnityWebRequest"/> and any network
+/// failures result in the caller receiving the local high score instead.
+/// </summary>
+public class LeaderboardClient : MonoBehaviour
+{
+    /// <summary>Global singleton instance.</summary>
+    public static LeaderboardClient Instance { get; private set; }
+
+    [Tooltip("Base URL of the leaderboard service e.g. https://example.com/api")]
+    public string serviceUrl = "http://localhost:8080";
+
+    [Tooltip("Name used when uploading scores. Defaults to 'Player'.")]
+    public string playerName = "Player";
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    /// <summary>
+    /// Represents a single leaderboard entry.
+    /// </summary>
+    [System.Serializable]
+    public struct ScoreEntry
+    {
+        public string name;
+        public int score;
+    }
+
+    [System.Serializable]
+    private class ScoreList
+    {
+        public ScoreEntry[] scores;
+    }
+
+    /// <summary>
+    /// Uploads <paramref name="score"/> associated with <see cref="playerName"/>.
+    /// The request body is JSON of the form {"name":"Player","score":100}.
+    /// </summary>
+    public IEnumerator UploadScore(int score)
+    {
+        string url = serviceUrl.TrimEnd('/') + "/scores";
+        string json = JsonUtility.ToJson(new ScoreEntry { name = playerName, score = score });
+
+        using (UnityWebRequest req = new UnityWebRequest(url, "POST"))
+        {
+            byte[] body = System.Text.Encoding.UTF8.GetBytes(json);
+            req.uploadHandler = new UploadHandlerRaw(body);
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+
+            bool success = false;
+            yield return SendWebRequest(req, (ok, _unused) => success = ok);
+            if (!success)
+            {
+                Debug.LogWarning("Failed to upload score to leaderboard");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Retrieves the top scores from the service. If the request fails or
+    /// returns invalid data, the local high score from
+    /// <see cref="SaveGameManager"/> is provided instead.
+    /// </summary>
+    public IEnumerator GetTopScores(System.Action<List<ScoreEntry>> callback)
+    {
+        string url = serviceUrl.TrimEnd('/') + "/scores";
+        List<ScoreEntry> result = null;
+
+        using (UnityWebRequest req = UnityWebRequest.Get(url))
+        {
+            req.downloadHandler = new DownloadHandlerBuffer();
+            bool success = false;
+            string text = null;
+            yield return SendWebRequest(req, (ok, data) => { success = ok; text = data; });
+            if (success)
+            {
+                result = ParseScores(text);
+            }
+        }
+
+        if (result == null || result.Count == 0)
+        {
+            int local = SaveGameManager.Instance != null ? SaveGameManager.Instance.HighScore : 0;
+            result = new List<ScoreEntry> { new ScoreEntry { name = "Local", score = local } };
+        }
+        callback?.Invoke(result);
+    }
+
+    /// <summary>
+    /// Issues the web request and invokes the callback with the outcome.
+    /// Tests override this method to provide fake responses.
+    /// </summary>
+    protected virtual IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> callback)
+    {
+        string text = null;
+        bool success = false;
+        try
+        {
+            yield return req.SendWebRequest();
+            if (req.result == UnityWebRequest.Result.Success)
+            {
+                text = req.downloadHandler.text;
+                success = true;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogWarning("Leaderboard request failed: " + ex.Message);
+        }
+        callback?.Invoke(success, text);
+    }
+
+    // Converts a raw JSON array into a list of score entries.
+    private List<ScoreEntry> ParseScores(string json)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return new List<ScoreEntry>();
+        }
+        try
+        {
+            // JsonUtility cannot parse a bare array so wrap it in an object
+            string wrapped = "{\"scores\":" + json + "}";
+            ScoreList list = JsonUtility.FromJson<ScoreList>(wrapped);
+            if (list != null && list.scores != null)
+            {
+                return new List<ScoreEntry>(list.scores);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogWarning("Failed to parse leaderboard JSON: " + ex.Message);
+        }
+        return new List<ScoreEntry>();
+    }
+}
+

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -28,6 +28,8 @@ public class UIManager : MonoBehaviour
     public Text coinScoreLabel;
     public GameObject leaderboardPanel;
     public Text leaderboardText;
+    [Tooltip("Client used for non-Steam leaderboard requests.")]
+    public LeaderboardClient leaderboardClient;
     public GameObject workshopPanel;
     public GameObject achievementsPanel;
     public GameObject shopPanel;
@@ -193,16 +195,16 @@ public class UIManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Displays the leaderboard panel and populates it with scores from Steam.
+    /// Displays the leaderboard panel and populates it with scores retrieved
+    /// from either Steam or the HTTP-based <see cref="LeaderboardClient"/>.
     /// </summary>
     public void ShowLeaderboard()
     {
-#if UNITY_STANDALONE
         ShowPanel(leaderboardPanel);
+#if UNITY_STANDALONE
         if (SteamManager.Instance != null)
         {
-            // Use the configured leaderboard ID from SteamManager so multiple
-            // boards can be supported across deployments.
+            // Use the configured leaderboard ID from SteamManager so multiple boards can be supported across deployments.
             string id = SteamManager.Instance.leaderboardId;
             SteamManager.Instance.FindOrCreateLeaderboard(id, success =>
             {
@@ -222,11 +224,36 @@ public class UIManager : MonoBehaviour
                         }
                     });
                 }
+                else if (leaderboardClient != null)
+                {
+                    StartCoroutine(leaderboardClient.GetTopScores(DisplayScores));
+                }
             });
         }
+        else if (leaderboardClient != null)
+        {
+            StartCoroutine(leaderboardClient.GetTopScores(DisplayScores));
+        }
 #else
-        ShowPanel(leaderboardPanel);
+        if (leaderboardClient != null)
+        {
+            StartCoroutine(leaderboardClient.GetTopScores(DisplayScores));
+        }
 #endif
+    }
+
+    // Helper to format and display leaderboard entries in the panel
+    private void DisplayScores(List<LeaderboardClient.ScoreEntry> scores)
+    {
+        if (leaderboardText != null && scores != null)
+        {
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < scores.Count; i++)
+            {
+                sb.AppendLine((i + 1) + ". " + scores[i].name + " - " + scores[i].score);
+            }
+            leaderboardText.text = sb.ToString();
+        }
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/LeaderboardClientTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tests for <see cref="LeaderboardClient"/> verifying JSON formatting and
+/// local fallback behaviour when web requests fail.
+/// </summary>
+public class LeaderboardClientTests
+{
+    private class DummyClient : LeaderboardClient
+    {
+        public UnityWebRequest sentRequest;
+        public bool succeed;
+        public string payload;
+
+        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> cb)
+        {
+            sentRequest = req;
+            cb?.Invoke(succeed, payload);
+            yield break;
+        }
+    }
+
+    [Test]
+    public void UploadScore_FormatsBody()
+    {
+        var go = new GameObject("lb");
+        var client = go.AddComponent<DummyClient>();
+        var routine = client.UploadScore(42);
+        while (routine.MoveNext()) { }
+
+        var raw = (UploadHandlerRaw)client.sentRequest.uploadHandler;
+        string body = System.Text.Encoding.UTF8.GetString(raw.data);
+        Assert.IsTrue(body.Contains("\"score\":42"));
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void GetTopScores_FallsBackToLocal()
+    {
+        System.IO.File.Delete(System.IO.Path.Combine(
+            Application.persistentDataPath, "savegame.json"));
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+        SaveGameManager.Instance.HighScore = 5;
+
+        var go = new GameObject("lb");
+        var client = go.AddComponent<DummyClient>();
+        client.succeed = false; // simulate failure
+
+        List<LeaderboardClient.ScoreEntry> result = null;
+        var routine = client.GetTopScores(list => result = list);
+        while (routine.MoveNext()) { }
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(5, result[0].score);
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(saveObj);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ The `SteamManager` component also exposes a **leaderboardId** field. Set this to
 the Steam leaderboard identifier you wish to use for global high scores. The
 UI's leaderboard panel queries this ID when downloading and uploading scores.
 
+For non-Steam versions of the game a lightweight HTTP leaderboard service is
+available via the new `LeaderboardClient` component. Configure its `serviceUrl`
+and reference it from `UIManager` to display scores retrieved from a REST
+endpoint. If the service cannot be reached the local high score is shown
+instead.
+
 ### Workshop Content
 The included `WorkshopManager` script uses Steamworks.NET's UGC API so you can
 share level or skin packs on the Steam Workshop.


### PR DESCRIPTION
## Summary
- add `LeaderboardClient` REST client for leaderboard service
- integrate leaderboard client with `UIManager` and `GameManager`
- show scores from HTTP service with local fallback
- document new client in README
- test JSON formatting and fallback behaviour

## Testing
- `npm test`
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b212915148321934638e3fb03ffb6