### PR TITLE
Add localization system with language persistence

### DIFF
--- a/Assets/Resources/Localization/en.json
+++ b/Assets/Resources/Localization/en.json
@@ -1,0 +1,14 @@
+{
+  "entries": [
+    {"key": "settings_language", "value": "Language"},
+    {"key": "settings_music_volume", "value": "Music Volume"},
+    {"key": "settings_effects_volume", "value": "Effects Volume"},
+    {"key": "settings_jump_key", "value": "Jump"},
+    {"key": "settings_slide_key", "value": "Slide"},
+    {"key": "settings_pause_key", "value": "Pause"},
+    {"key": "final_score_format", "value": "Score: {0}"},
+    {"key": "high_score_format", "value": "High Score: {0}"},
+    {"key": "coins_format", "value": "Coins: {0}"},
+    {"key": "percentage_format", "value": "{0}%"}
+  ]
+}

--- a/Assets/Resources/Localization/es.json
+++ b/Assets/Resources/Localization/es.json
@@ -1,0 +1,14 @@
+{
+  "entries": [
+    {"key": "settings_language", "value": "Idioma"},
+    {"key": "settings_music_volume", "value": "Volumen de Música"},
+    {"key": "settings_effects_volume", "value": "Volumen de Efectos"},
+    {"key": "settings_jump_key", "value": "Saltar"},
+    {"key": "settings_slide_key", "value": "Deslizar"},
+    {"key": "settings_pause_key", "value": "Pausa"},
+    {"key": "final_score_format", "value": "Puntuación: {0}"},
+    {"key": "high_score_format", "value": "Récord: {0}"},
+    {"key": "coins_format", "value": "Monedas: {0}"},
+    {"key": "percentage_format", "value": "{0}%"}
+  ]
+}

--- a/Assets/Scripts/LocalizationManager.cs
+++ b/Assets/Scripts/LocalizationManager.cs
@@ -1,0 +1,121 @@
+// LocalizationManager.cs
+// -----------------------------------------------------------------------------
+// Simple runtime localization service for fetching translated strings. Language
+// tables are loaded from JSON files stored under Resources/Localization. Each
+// file contains an array of key/value pairs that map string identifiers to
+// translations. The manager exposes methods to change the active language and
+// retrieve strings by key. Missing keys return the key itself so callers can
+// detect untranslated values.
+// -----------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// Loads and provides access to translated strings at runtime. Translation files
+/// live in <c>Resources/Localization</c> and are named by language code such as
+/// "en" or "es". Each file must contain a JSON object with an <c>entries</c>
+/// array. Example:
+/// <code>
+/// {
+///   "entries": [ { "key": "greeting", "value": "Hello" } ]
+/// }
+/// </code>
+/// </summary>
+public static class LocalizationManager
+{
+    private const string ResourcesPath = "Localization"; // subfolder under Resources
+    private static readonly Dictionary<string, string> table = new Dictionary<string, string>();
+    private static string currentLanguage = "en";
+
+    /// <summary>Raised when <see cref="SetLanguage"/> changes the active table.</summary>
+    public static event System.Action OnLanguageChanged;
+
+    /// <summary>Currently active language code.</summary>
+    public static string CurrentLanguage => currentLanguage;
+
+    /// <summary>
+    /// List of available languages derived from JSON files placed under
+    /// <c>Resources/Localization</c>.
+    /// </summary>
+    public static IEnumerable<string> AvailableLanguages
+    {
+        get
+        {
+            return Resources.LoadAll<TextAsset>(ResourcesPath)
+                .Select(a => a.name)
+                .ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Changes the active language and reloads the corresponding table. If the
+    /// file cannot be found the table becomes empty and missing keys will return
+    /// their identifier.
+    /// </summary>
+    /// <param name="language">Language code such as "en" or "es".</param>
+    public static void SetLanguage(string language)
+    {
+        currentLanguage = language;
+        LoadTable(language);
+        OnLanguageChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Retrieves the translated string for the provided key. If no entry exists
+    /// the key itself is returned.
+    /// </summary>
+    public static string Get(string key)
+    {
+        if (!table.ContainsKey(key))
+        {
+            return key;
+        }
+        return table[key];
+    }
+
+    // Loads the table for the specified language code from Resources.
+    private static void LoadTable(string language)
+    {
+        table.Clear();
+        TextAsset asset = Resources.Load<TextAsset>($"{ResourcesPath}/{language}");
+        if (asset == null)
+        {
+            Debug.LogWarning($"Localization file not found for language '{language}'.");
+            return;
+        }
+        try
+        {
+            LocalizationFile wrapper = JsonUtility.FromJson<LocalizationFile>(asset.text);
+            if (wrapper != null && wrapper.entries != null)
+            {
+                foreach (var entry in wrapper.entries)
+                {
+                    if (!string.IsNullOrEmpty(entry.key))
+                    {
+                        table[entry.key] = entry.value ?? string.Empty;
+                    }
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogError("Failed to parse localization JSON: " + ex.Message);
+        }
+    }
+
+    // Helper types used to deserialize the JSON structure.
+    [System.Serializable]
+    private class LocalizationFile
+    {
+        public LocalizationEntry[] entries;
+    }
+
+    [System.Serializable]
+    private class LocalizationEntry
+    {
+        public string key;
+        public string value;
+    }
+}

--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -42,11 +42,12 @@ public class SaveGameManager : MonoBehaviour
         public int highScore;
         public float musicVolume = 1f;   // range 0-1
         public float effectsVolume = 1f; // range 0-1
+        public string language = "en";   // language code
         public List<UpgradeEntry> upgrades = new List<UpgradeEntry>();
     }
 
     // Version value written to disk alongside <see cref="SaveData"/>.
-    private const int CurrentVersion = 1;
+    private const int CurrentVersion = 2;
 
     private const string CoinsKey = "ShopCoins";       // legacy PlayerPrefs key
     private const string UpgradePrefix = "UpgradeLevel_"; // legacy PlayerPrefs prefix
@@ -115,6 +116,21 @@ public class SaveGameManager : MonoBehaviour
         }
     }
 
+    /// <summary>Currently selected language code.</summary>
+    public string Language
+    {
+        get => data.language;
+        set
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                data.language = value;
+                SaveDataToFile();
+                LocalizationManager.SetLanguage(value);
+            }
+        }
+    }
+
     /// <summary>Returns the purchased level count for an upgrade.</summary>
     public int GetUpgradeLevel(UpgradeType type)
     {
@@ -149,12 +165,18 @@ public class SaveGameManager : MonoBehaviour
                         loaded.musicVolume = 1f;
                         loaded.effectsVolume = 1f;
                     }
+                    if (loaded.version < 2)
+                    {
+                        loaded.language = "en";
+                    }
 
                     data.coins = loaded.coins;
                     data.highScore = loaded.highScore;
                     data.musicVolume = Mathf.Clamp01(loaded.musicVolume);
                     data.effectsVolume = Mathf.Clamp01(loaded.effectsVolume);
-
+                    data.language = loaded.language ?? "en";
+                    LocalizationManager.SetLanguage(data.language);
+                    
                     upgradeLevels.Clear();
                     foreach (var entry in loaded.upgrades)
                     {
@@ -180,6 +202,7 @@ public class SaveGameManager : MonoBehaviour
             data.highScore = PlayerPrefs.GetInt(HighScoreKey, 0);
             data.musicVolume = 1f;
             data.effectsVolume = 1f;
+            data.language = "en";
             foreach (UpgradeType type in Enum.GetValues(typeof(UpgradeType)))
             {
                 int level = PlayerPrefs.GetInt(UpgradePrefix + type, 0);
@@ -190,6 +213,7 @@ public class SaveGameManager : MonoBehaviour
             }
             // Persist the newly created data so future loads skip migration.
             SaveDataToFile();
+            LocalizationManager.SetLanguage(data.language);
         }
     }
 
@@ -203,6 +227,10 @@ public class SaveGameManager : MonoBehaviour
         data.version = CurrentVersion;
         data.musicVolume = Mathf.Clamp01(data.musicVolume);
         data.effectsVolume = Mathf.Clamp01(data.effectsVolume);
+        if (string.IsNullOrEmpty(data.language))
+        {
+            data.language = "en";
+        }
         data.upgrades.Clear();
         foreach (var kvp in upgradeLevels)
         {

--- a/Assets/Scripts/SettingsMenu.cs
+++ b/Assets/Scripts/SettingsMenu.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using System.Collections.Generic;
 
 /// <summary>
 /// Provides UI hooks for changing key bindings and colorblind mode. When the
@@ -16,6 +17,7 @@ public class SettingsMenu : MonoBehaviour
     public Text musicVolumeLabel;
     public Slider effectsVolumeSlider;
     public Text effectsVolumeLabel;
+    public Dropdown languageDropdown;
 
     /// <summary>
     /// Populates UI elements with the current settings on start.
@@ -35,6 +37,19 @@ public class SettingsMenu : MonoBehaviour
         {
             effectsVolumeSlider.value = SaveGameManager.Instance.EffectsVolume;
             UpdateEffectsVolumeLabel(effectsVolumeSlider.value);
+        }
+        if (languageDropdown != null)
+        {
+            languageDropdown.ClearOptions();
+            var options = new List<Dropdown.OptionData>();
+            foreach (string lang in LocalizationManager.AvailableLanguages)
+            {
+                options.Add(new Dropdown.OptionData(lang));
+            }
+            languageDropdown.options = options;
+            string current = SaveGameManager.Instance != null ? SaveGameManager.Instance.Language : LocalizationManager.CurrentLanguage;
+            int index = options.FindIndex(o => o.text == current);
+            languageDropdown.value = index >= 0 ? index : 0;
         }
     }
 
@@ -140,12 +155,30 @@ public class SettingsMenu : MonoBehaviour
         UpdateEffectsVolumeLabel(value);
     }
 
+    /// <summary>
+    /// Callback for the language dropdown. Persists the selected language and
+    /// reloads translations via <see cref="LocalizationManager"/>.
+    /// </summary>
+    public void ChangeLanguage(int index)
+    {
+        if (languageDropdown == null || index < 0 || index >= languageDropdown.options.Count)
+            return;
+
+        string lang = languageDropdown.options[index].text;
+        LocalizationManager.SetLanguage(lang);
+        if (SaveGameManager.Instance != null)
+        {
+            SaveGameManager.Instance.Language = lang;
+        }
+    }
+
     // Updates the on-screen music volume percentage if a label is assigned.
     private void UpdateMusicVolumeLabel(float value)
     {
         if (musicVolumeLabel != null)
         {
-            musicVolumeLabel.text = Mathf.RoundToInt(value * 100f) + "%";
+            string fmt = LocalizationManager.Get("percentage_format");
+            musicVolumeLabel.text = string.Format(fmt, Mathf.RoundToInt(value * 100f));
         }
     }
 
@@ -154,7 +187,8 @@ public class SettingsMenu : MonoBehaviour
     {
         if (effectsVolumeLabel != null)
         {
-            effectsVolumeLabel.text = Mathf.RoundToInt(value * 100f) + "%";
+            string fmt = LocalizationManager.Get("percentage_format");
+            effectsVolumeLabel.text = string.Format(fmt, Mathf.RoundToInt(value * 100f));
         }
     }
 }

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -147,15 +147,18 @@ public class UIManager : MonoBehaviour
     {
         if (finalScoreLabel != null)
         {
-            finalScoreLabel.text = score.ToString();
+            string fmt = LocalizationManager.Get("final_score_format");
+            finalScoreLabel.text = string.Format(fmt, score);
         }
         if (highScoreLabel != null)
         {
-            highScoreLabel.text = highScore.ToString();
+            string fmt = LocalizationManager.Get("high_score_format");
+            highScoreLabel.text = string.Format(fmt, highScore);
         }
         if (coinScoreLabel != null)
         {
-            coinScoreLabel.text = coins.ToString();
+            string fmt = LocalizationManager.Get("coins_format");
+            coinScoreLabel.text = string.Format(fmt, coins);
         }
         ShowPanel(gameOverPanel);
     }

--- a/Assets/Tests/EditMode/LocalizationManagerTests.cs
+++ b/Assets/Tests/EditMode/LocalizationManagerTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using UnityEngine;
+
+/// <summary>
+/// Tests for <see cref="LocalizationManager"/> verifying language switching and
+/// value retrieval from the JSON tables located under Resources/Localization.
+/// </summary>
+public class LocalizationManagerTests
+{
+    [Test]
+    public void Get_ReturnsTranslatedValue()
+    {
+        LocalizationManager.SetLanguage("en");
+        Assert.AreEqual("Language", LocalizationManager.Get("settings_language"));
+
+        LocalizationManager.SetLanguage("es");
+        Assert.AreEqual("Idioma", LocalizationManager.Get("settings_language"));
+    }
+}

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -112,4 +112,19 @@ public class SaveGameManagerTests
         string json = File.ReadAllText(path);
         Assert.IsTrue(json.Contains("\"version\""));
     }
+
+    [Test]
+    public void LanguageValue_IsPersisted()
+    {
+        // Save a language preference and ensure it loads correctly on next startup
+        var go = new GameObject("save");
+        var save = go.AddComponent<SaveGameManager>();
+        save.Language = "es";
+        Object.DestroyImmediate(go);
+
+        var go2 = new GameObject("save2");
+        var save2 = go2.AddComponent<SaveGameManager>();
+        Assert.AreEqual("es", save2.Language);
+        Object.DestroyImmediate(go2);
+    }
 }


### PR DESCRIPTION
## Summary
- implement `LocalizationManager` for loading language tables from Resources
- persist chosen language in `SaveGameManager`
- show localized text in `UIManager` and `SettingsMenu`
- expose language dropdown in settings menu
- include English and Spanish translation samples
- extend unit tests for localization and language persistence

## Testing
- `npm test`