### PR TITLE
Localize achievements and leaderboard entries

### DIFF
--- a/Assets/Resources/Localization/en.json
+++ b/Assets/Resources/Localization/en.json
@@ -9,6 +9,19 @@
     {"key": "final_score_format", "value": "Score: {0}"},
     {"key": "high_score_format", "value": "High Score: {0}"},
     {"key": "coins_format", "value": "Coins: {0}"},
-    {"key": "percentage_format", "value": "{0}%"}
+    {"key": "percentage_format", "value": "{0}%"},
+    {"key": "ach_distance_1000_name", "value": "Traveler"},
+    {"key": "ach_distance_1000_desc", "value": "Travel 1000m in a single run."},
+    {"key": "ach_distance_5000_name", "value": "Marathon"},
+    {"key": "ach_distance_5000_desc", "value": "Travel 5000m in a single run."},
+    {"key": "ach_coins_50_name", "value": "Treasure Hunter"},
+    {"key": "ach_coins_50_desc", "value": "Collect 50 coins."},
+    {"key": "ach_coins_200_name", "value": "Gold Hoarder"},
+    {"key": "ach_coins_200_desc", "value": "Collect 200 coins."},
+    {"key": "ach_daily_complete_name", "value": "Daily Warrior"},
+    {"key": "ach_daily_complete_desc", "value": "Complete a daily challenge."},
+    {"key": "leaderboard_entry_format", "value": "{0}. {1} - {2}"},
+    {"key": "leaderboard_local_player", "value": "Local"},
+    {"key": "achievement_unlocked", "value": " (Unlocked)"}
   ]
 }

--- a/Assets/Resources/Localization/es.json
+++ b/Assets/Resources/Localization/es.json
@@ -9,6 +9,19 @@
     {"key": "final_score_format", "value": "Puntuación: {0}"},
     {"key": "high_score_format", "value": "Récord: {0}"},
     {"key": "coins_format", "value": "Monedas: {0}"},
-    {"key": "percentage_format", "value": "{0}%"}
+    {"key": "percentage_format", "value": "{0}%"},
+    {"key": "ach_distance_1000_name", "value": "Viajero"},
+    {"key": "ach_distance_1000_desc", "value": "Recorre 1000 m en una sola partida."},
+    {"key": "ach_distance_5000_name", "value": "Maratón"},
+    {"key": "ach_distance_5000_desc", "value": "Recorre 5000 m en una sola partida."},
+    {"key": "ach_coins_50_name", "value": "Cazador de Tesoros"},
+    {"key": "ach_coins_50_desc", "value": "Consigue 50 monedas."},
+    {"key": "ach_coins_200_name", "value": "Acaparador de Oro"},
+    {"key": "ach_coins_200_desc", "value": "Consigue 200 monedas."},
+    {"key": "ach_daily_complete_name", "value": "Guerrero Diario"},
+    {"key": "ach_daily_complete_desc", "value": "Completa un desafío diario."},
+    {"key": "leaderboard_entry_format", "value": "{0}. {1} - {2}"},
+    {"key": "leaderboard_local_player", "value": "Local ES"},
+    {"key": "achievement_unlocked", "value": " (Desbloqueado)"}
   ]
 }

--- a/Assets/Scripts/AchievementsMenu.cs
+++ b/Assets/Scripts/AchievementsMenu.cs
@@ -35,8 +35,8 @@ public class AchievementsMenu : MonoBehaviour
         for (int i = 0; i < count; i++)
         {
             string id = SteamUserStats.GetAchievementName(i);
-            string name = SteamUserStats.GetAchievementDisplayAttribute(id, "name");
-            string desc = SteamUserStats.GetAchievementDisplayAttribute(id, "desc");
+            string name = SteamManager.GetAchievementName(id);
+            string desc = SteamManager.GetAchievementDescription(id);
             bool achieved;
             SteamUserStats.GetAchievement(id, out achieved);
 
@@ -44,7 +44,8 @@ public class AchievementsMenu : MonoBehaviour
             Text text = entry.GetComponentInChildren<Text>();
             if (text != null)
             {
-                text.text = string.Format("{0} - {1}{2}", name, desc, achieved ? " (Unlocked)" : "");
+                string unlocked = achieved ? LocalizationManager.Get("achievement_unlocked") : string.Empty;
+                text.text = string.Format("{0} - {1}{2}", name, desc, unlocked);
             }
         }
 #endif

--- a/Assets/Scripts/LeaderboardClient.cs
+++ b/Assets/Scripts/LeaderboardClient.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
 
+// LocalizationManager is used to fetch translated strings for fallback labels.
+// This revision reads the local-player label and entry format from the
+// localization tables so leaderboard text updates when the language changes.
+
 /// <summary>
 /// Client for a simple REST-based leaderboard service used when Steamworks
 /// is unavailable. The service exposes two endpoints:
@@ -111,7 +115,8 @@ public class LeaderboardClient : MonoBehaviour
         if (result == null || result.Count == 0)
         {
             int local = SaveGameManager.Instance != null ? SaveGameManager.Instance.HighScore : 0;
-            result = new List<ScoreEntry> { new ScoreEntry { name = "Local", score = local } };
+            string name = LocalizationManager.Get("leaderboard_local_player");
+            result = new List<ScoreEntry> { new ScoreEntry { name = name, score = local } };
         }
         callback?.Invoke(result);
     }

--- a/Assets/Scripts/SteamManager.cs
+++ b/Assets/Scripts/SteamManager.cs
@@ -2,16 +2,39 @@ using UnityEngine;
 #if UNITY_STANDALONE
 using Steamworks;
 #endif
+using System.Collections.Generic;
 
 /// <summary>
 /// Handles initialization of the Steamworks API, achievement unlocking,
 /// cloud saves and leaderboard submission. The leaderboard identifier can
 /// be configured in the inspector so different boards may be used in
-/// various builds.
+/// various builds. This revision adds helper methods to fetch localized
+/// achievement names and descriptions via <see cref="LocalizationManager"/>.
 /// </summary>
 public class SteamManager : MonoBehaviour
 {
     public static SteamManager Instance { get; private set; }
+
+    // Mapping of Steam achievement identifiers to localization keys for
+    // display names and descriptions. These tables allow the UI to fetch
+    // translated strings without relying on Steam's built-in text.
+    private static readonly Dictionary<string, string> achievementNameKeys = new Dictionary<string, string>
+    {
+        { "ACH_DISTANCE_1000", "ach_distance_1000_name" },
+        { "ACH_DISTANCE_5000", "ach_distance_5000_name" },
+        { "ACH_COINS_50", "ach_coins_50_name" },
+        { "ACH_COINS_200", "ach_coins_200_name" },
+        { "ACH_DAILY_COMPLETE", "ach_daily_complete_name" }
+    };
+
+    private static readonly Dictionary<string, string> achievementDescKeys = new Dictionary<string, string>
+    {
+        { "ACH_DISTANCE_1000", "ach_distance_1000_desc" },
+        { "ACH_DISTANCE_5000", "ach_distance_5000_desc" },
+        { "ACH_COINS_50", "ach_coins_50_desc" },
+        { "ACH_COINS_200", "ach_coins_200_desc" },
+        { "ACH_DAILY_COMPLETE", "ach_daily_complete_desc" }
+    };
 
 #if UNITY_STANDALONE
     private bool initialized;
@@ -131,6 +154,32 @@ public class SteamManager : MonoBehaviour
         }
 #endif
         return 0;
+    }
+
+    /// <summary>
+    /// Retrieves the localized display name for the given achievement.
+    /// Falls back to <paramref name="id"/> when no mapping exists.
+    /// </summary>
+    public static string GetAchievementName(string id)
+    {
+        if (achievementNameKeys.TryGetValue(id, out string key))
+        {
+            return LocalizationManager.Get(key);
+        }
+        return id;
+    }
+
+    /// <summary>
+    /// Retrieves the localized description for the given achievement.
+    /// Returns <paramref name="id"/> if no translation key is defined.
+    /// </summary>
+    public static string GetAchievementDescription(string id)
+    {
+        if (achievementDescKeys.TryGetValue(id, out string key))
+        {
+            return LocalizationManager.Get(key);
+        }
+        return id;
     }
 
 #if UNITY_STANDALONE

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -218,10 +218,11 @@ public class UIManager : MonoBehaviour
                         if (leaderboardText != null && entries != null)
                         {
                             var sb = new System.Text.StringBuilder();
+                            string fmt = LocalizationManager.Get("leaderboard_entry_format");
                             for (int i = 0; i < entries.Length; i++)
                             {
                                 string name = SteamFriends.GetFriendPersonaName(entries[i].m_steamIDUser);
-                                sb.AppendLine((i + 1) + ". " + name + " - " + entries[i].m_nScore);
+                                sb.AppendLine(string.Format(fmt, i + 1, name, entries[i].m_nScore));
                             }
                             leaderboardText.text = sb.ToString();
                         }
@@ -251,9 +252,10 @@ public class UIManager : MonoBehaviour
         if (leaderboardText != null && scores != null)
         {
             var sb = new System.Text.StringBuilder();
+            string fmt = LocalizationManager.Get("leaderboard_entry_format");
             for (int i = 0; i < scores.Count; i++)
             {
-                sb.AppendLine((i + 1) + ". " + scores[i].name + " - " + scores[i].score);
+                sb.AppendLine(string.Format(fmt, i + 1, scores[i].name, scores[i].score));
             }
             leaderboardText.text = sb.ToString();
         }

--- a/Assets/Tests/EditMode/LeaderboardClientTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientTests.cs
@@ -60,4 +60,30 @@ public class LeaderboardClientTests
         Object.DestroyImmediate(go);
         Object.DestroyImmediate(saveObj);
     }
+
+    /// <summary>
+    /// Fallback entry name should change based on the current language.
+    /// </summary>
+    [Test]
+    public void GetTopScores_UsesLocalizedName()
+    {
+        System.IO.File.Delete(System.IO.Path.Combine(
+            Application.persistentDataPath, "savegame.json"));
+        var saveObj = new GameObject("saveL");
+        saveObj.AddComponent<SaveGameManager>();
+        SaveGameManager.Instance.HighScore = 2;
+
+        var go = new GameObject("lb");
+        var client = go.AddComponent<DummyClient>();
+        client.succeed = false;
+
+        LocalizationManager.SetLanguage("es");
+        List<LeaderboardClient.ScoreEntry> result = null;
+        var routine = client.GetTopScores(list => result = list);
+        while (routine.MoveNext()) { }
+
+        Assert.AreEqual("Local ES", result[0].name);
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(saveObj);
+    }
 }

--- a/Assets/Tests/EditMode/SteamManagerTests.cs
+++ b/Assets/Tests/EditMode/SteamManagerTests.cs
@@ -76,4 +76,16 @@ public class SteamManagerTests
         Assert.Pass("Steamworks not available");
 #endif
     }
+
+    /// <summary>
+    /// Achievement display strings should reflect the active language.
+    /// </summary>
+    [Test]
+    public void AchievementStrings_Localized()
+    {
+        LocalizationManager.SetLanguage("en");
+        Assert.AreEqual("Traveler", SteamManager.GetAchievementName("ACH_DISTANCE_1000"));
+        LocalizationManager.SetLanguage("es");
+        Assert.AreEqual("Viajero", SteamManager.GetAchievementName("ACH_DISTANCE_1000"));
+    }
 }


### PR DESCRIPTION
## Summary
- add localization entries for achievements and leaderboard labels
- fetch achievement names/descriptions from `LocalizationManager`
- format leaderboard entries using localized strings
- localize fallback player name for HTTP leaderboard
- add tests covering language switching behavior

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found)*