### PR TITLE
Add rumble feedback support

### DIFF
--- a/Assets/Scripts/CoinBonusPowerUp.cs
+++ b/Assets/Scripts/CoinBonusPowerUp.cs
@@ -42,6 +42,7 @@ public class CoinBonusPowerUp : MonoBehaviour
         {
             AudioManager.Instance.PlaySound(collectClip);
         }
+        InputManager.TriggerRumble(0.3f, 0.1f);
         // Return to pool if pooled, otherwise destroy.
         PooledObject po = GetComponent<PooledObject>();
         if (po != null && po.Pool != null)

--- a/Assets/Scripts/GravityFlipPowerUp.cs
+++ b/Assets/Scripts/GravityFlipPowerUp.cs
@@ -28,6 +28,7 @@ public class GravityFlipPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+            InputManager.TriggerRumble(0.3f, 0.1f);
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
+using System.Collections;
 
 /// <summary>
 /// Centralised helper for reading player input. This file was expanded to
@@ -18,6 +19,8 @@ public static class InputManager
     private const string JumpPref = "JumpKey";
     private const string SlidePref = "SlideKey";
     private const string PausePref = "PauseKey";
+    // Preference key storing whether vibration is enabled.
+    private const string RumblePref = "RumbleEnabled";
     // New preference key used for the fast fall / down action.
     private const string DownPref = "DownKey";
     // Preference keys for custom left and right movement when using the
@@ -40,6 +43,10 @@ public static class InputManager
     private static InputAction pauseAction;
     private static InputAction downAction;
     private static InputAction moveAction;
+    // Host MonoBehaviour used for running rumble coroutines.
+    private static RumbleHost rumbleHost;
+    // Reference to the currently running rumble coroutine so it can be stopped.
+    private static Coroutine rumbleRoutine;
 #endif
 
     // Joystick button codes for legacy input manager support. These arrays
@@ -82,6 +89,8 @@ public static class InputManager
     // Keys used for horizontal movement when the legacy input manager is active.
     public static KeyCode MoveLeftKey { get; private set; }
     public static KeyCode MoveRightKey { get; private set; }
+    // True when controller rumble is allowed. Controlled via SettingsMenu.
+    public static bool RumbleEnabled { get; private set; }
 
     static InputManager()
     {
@@ -94,8 +103,15 @@ public static class InputManager
         // WASD controls are enabled by default for horizontal movement.
         MoveLeftKey = LoadKey(LeftPref, KeyCode.A);
         MoveRightKey = LoadKey(RightPref, KeyCode.D);
-
+        // Load rumble preference (enabled by default).
+        RumbleEnabled = PlayerPrefs.GetInt(RumblePref, 1) == 1;
 #if ENABLE_INPUT_SYSTEM
+        // Create a hidden object for coroutine execution so rumble can
+        // run without requiring a separate manager component.
+        var hostObj = new GameObject("InputManagerRumbleHost");
+        hostObj.hideFlags = HideFlags.HideAndDontSave;
+        Object.DontDestroyOnLoad(hostObj);
+        rumbleHost = hostObj.AddComponent<RumbleHost>();
         // Setup actions so either keyboard or various gamepads can trigger them.
         jumpAction = new InputAction("Jump", InputActionType.Button);
         jumpAction.AddBinding(PlayerPrefs.GetString(JumpBindingPref, "<Keyboard>/space"));
@@ -221,6 +237,16 @@ public static class InputManager
     {
         PauseKey = key;
         PlayerPrefs.SetString(PausePref, key.ToString());
+        PlayerPrefs.Save();
+    }
+
+    /// <summary>
+    /// Enables or disables controller rumble feedback.
+    /// </summary>
+    public static void SetRumbleEnabled(bool enabled)
+    {
+        RumbleEnabled = enabled;
+        PlayerPrefs.SetInt(RumblePref, enabled ? 1 : 0);
         PlayerPrefs.Save();
     }
 
@@ -596,4 +622,35 @@ public static class InputManager
             return axis;
         return Input.GetAxisRaw("Horizontal");
     }
+
+#if ENABLE_INPUT_SYSTEM
+    /// <summary>
+    /// Triggers controller rumble using the current gamepad. The effect stops
+    /// automatically after the supplied duration.
+    /// </summary>
+    public static void TriggerRumble(float strength, float duration)
+    {
+        if (!RumbleEnabled || Gamepad.current == null)
+            return;
+
+        strength = Mathf.Clamp01(strength);
+        duration = Mathf.Max(0f, duration);
+
+        if (rumbleRoutine != null)
+            rumbleHost.StopCoroutine(rumbleRoutine);
+
+        rumbleRoutine = rumbleHost.StartCoroutine(RumbleRoutine(strength, duration));
+    }
+
+    // Coroutine that applies rumble then resets the motor speeds.
+    private static IEnumerator RumbleRoutine(float strength, float duration)
+    {
+        Gamepad.current.SetMotorSpeeds(strength, strength);
+        yield return new WaitForSeconds(duration);
+        Gamepad.current.SetMotorSpeeds(0f, 0f);
+    }
+
+    // Lightweight MonoBehaviour used solely to run coroutines for rumble.
+    private class RumbleHost : MonoBehaviour {}
+#endif
 }

--- a/Assets/Scripts/MagnetPowerUp.cs
+++ b/Assets/Scripts/MagnetPowerUp.cs
@@ -37,6 +37,8 @@ public class MagnetPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+            // Light rumble to acknowledge the pickup.
+            InputManager.TriggerRumble(0.3f, 0.1f);
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -241,6 +241,8 @@ public class PlayerController : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(jumpClip);
             }
+            // Provide haptic feedback so jumps feel responsive.
+            InputManager.TriggerRumble(0.5f, 0.1f);
             if (!isGrounded && jumpsRemaining > 0)
             {
                 jumpsRemaining--;
@@ -345,6 +347,8 @@ public class PlayerController : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(hitClip);
             }
+            // Strong rumble feedback on taking damage.
+            InputManager.TriggerRumble(1f, 0.3f);
             if (GameManager.Instance != null && !GameManager.Instance.IsGameOver())
             {
                 GameManager.Instance.GameOver();

--- a/Assets/Scripts/SettingsMenu.cs
+++ b/Assets/Scripts/SettingsMenu.cs
@@ -18,6 +18,7 @@ public class SettingsMenu : MonoBehaviour
     public Slider effectsVolumeSlider;
     public Text effectsVolumeLabel;
     public Dropdown languageDropdown;
+    public Toggle rumbleToggle;
 
     /// <summary>
     /// Populates UI elements with the current settings on start.
@@ -28,6 +29,7 @@ public class SettingsMenu : MonoBehaviour
         if (slideKeyLabel != null) slideKeyLabel.text = InputManager.SlideKey.ToString();
         if (pauseKeyLabel != null) pauseKeyLabel.text = InputManager.PauseKey.ToString();
         if (colorblindToggle != null) colorblindToggle.isOn = ColorblindManager.Enabled;
+        if (rumbleToggle != null) rumbleToggle.isOn = InputManager.RumbleEnabled;
         if (musicVolumeSlider != null && SaveGameManager.Instance != null)
         {
             musicVolumeSlider.value = SaveGameManager.Instance.MusicVolume;
@@ -120,6 +122,14 @@ public class SettingsMenu : MonoBehaviour
     public void ToggleColorblind(bool value)
     {
         ColorblindManager.SetEnabled(value);
+    }
+
+    /// <summary>
+    /// Enables or disables controller rumble via the settings toggle.
+    /// </summary>
+    public void ToggleRumble(bool value)
+    {
+        InputManager.SetRumbleEnabled(value);
     }
 
     /// <summary>

--- a/Assets/Scripts/ShieldPowerUp.cs
+++ b/Assets/Scripts/ShieldPowerUp.cs
@@ -35,6 +35,8 @@ public class ShieldPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+            // Brief vibration feedback on pickup.
+            InputManager.TriggerRumble(0.3f, 0.1f);
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/SlowMotionPowerUp.cs
+++ b/Assets/Scripts/SlowMotionPowerUp.cs
@@ -35,6 +35,7 @@ public class SlowMotionPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+            InputManager.TriggerRumble(0.3f, 0.1f);
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/SpeedBoostPowerUp.cs
+++ b/Assets/Scripts/SpeedBoostPowerUp.cs
@@ -38,6 +38,8 @@ public class SpeedBoostPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+            // Provide subtle feedback on collection.
+            InputManager.TriggerRumble(0.3f, 0.1f);
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -58,5 +58,19 @@ public class InputManagerTests
 
         Assert.IsTrue(hasComposite, "Move action should use a 1DAxis composite for keyboard input");
     }
+
+    [Test]
+    public void TriggerRumble_StartsCoroutine()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        InputManager.SetRumbleEnabled(true);
+
+        InputManager.TriggerRumble(0.5f, 0.01f);
+
+        FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field, "rumbleRoutine field missing");
+        Assert.IsNotNull(field.GetValue(null), "TriggerRumble should start a coroutine when a gamepad is present");
+        InputSystem.RemoveDevice(gamepad);
+    }
 }
 #endif

--- a/Assets/Tests/EditMode/PlayerControllerTests.cs
+++ b/Assets/Tests/EditMode/PlayerControllerTests.cs
@@ -1,6 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 /// <summary>
 /// Tests for PlayerController. Specifically verifies that the new
@@ -178,5 +181,30 @@ public class PlayerControllerTests
 
         Object.DestroyImmediate(player);
     }
+
+#if ENABLE_INPUT_SYSTEM
+    [Test]
+    public void AttemptJump_TriggersRumble()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var player = new GameObject("player");
+        player.AddComponent<Rigidbody2D>();
+        player.AddComponent<CapsuleCollider2D>();
+        var pc = player.AddComponent<PlayerController>();
+
+        typeof(PlayerController).GetField("isGrounded", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(pc, true);
+
+        InputManager.SetRumbleEnabled(true);
+        typeof(PlayerController).GetMethod("AttemptJump", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pc, null);
+
+        FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field.GetValue(null), "Rumble should start when jumping with a gamepad connected");
+
+        Object.DestroyImmediate(player);
+        InputSystem.RemoveDevice(gamepad);
+    }
+#endif
 }
 

--- a/Assets/Tests/EditMode/ShieldPowerUpTests.cs
+++ b/Assets/Tests/EditMode/ShieldPowerUpTests.cs
@@ -1,6 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 /// <summary>
 /// Unit tests verifying that <see cref="ShieldPowerUp"/> correctly grants the
@@ -118,4 +121,32 @@ public class ShieldPowerUpTests
         Object.DestroyImmediate(poolObj);
         Object.DestroyImmediate(player);
     }
+
+#if ENABLE_INPUT_SYSTEM
+    [Test]
+    public void OnTriggerEnter_TriggersRumble()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var player = new GameObject("player");
+        player.tag = "Player";
+        player.AddComponent<PlayerShield>();
+        var playerCol = player.AddComponent<BoxCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var sp = powerObj.AddComponent<ShieldPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+
+        InputManager.SetRumbleEnabled(true);
+        sp.OnTriggerEnter2D(playerCol);
+
+        FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field.GetValue(null), "Collecting the power-up should start a rumble coroutine");
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        InputSystem.RemoveDevice(gamepad);
+    }
+#endif
 }


### PR DESCRIPTION
## Summary
- add rumble support in `InputManager` using `Gamepad.current`
- rumble on player jump, hitting obstacles and power-up pickup
- new toggle in `SettingsMenu` to disable rumble
- unit tests for rumble behaviour with a mock gamepad

## Testing
- `npm test`