### PR TITLE
Add tests for spawner timing and object pool edges

### DIFF
--- a/Assets/Tests/EditMode/HazardSpawnerTests.cs
+++ b/Assets/Tests/EditMode/HazardSpawnerTests.cs
@@ -1,0 +1,84 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tests for <see cref="HazardSpawner"/> ensuring spawn timing respects
+/// the stage multiplier and that hazards are obtained from pools when
+/// pooling is enabled.
+/// </summary>
+public class HazardSpawnerTests
+{
+    [Test]
+    public void Update_UsesSpawnMultiplierForTimer()
+    {
+        // Create a running GameManager to satisfy the spawner's check.
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("isRunning", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, true);
+
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<HazardSpawner>();
+        spawner.usePooling = false;
+        spawner.pitPrefabs = new[] { new GameObject("prefab") };
+        spawner.spawnInterval = 2f;
+        spawner.spawnMultiplier = 0.5f; // slower spawns when below 1
+        spawner.spawnRateCurve = AnimationCurve.Constant(0f, 1f, 1f);
+
+        typeof(HazardSpawner).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(spawner, 0f);
+
+        spawner.Update();
+
+        float timer = (float)typeof(HazardSpawner).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(spawner);
+
+        // Multiplier below 1 should lengthen the interval: 2f / (1 * 0.5) = 4f
+        Assert.AreEqual(4f, timer, 0.0001f,
+            "Spawn timer should increase when multiplier is less than 1");
+
+        Object.DestroyImmediate(spawner.pitPrefabs[0]);
+        Object.DestroyImmediate(spawnerObj);
+        Object.DestroyImmediate(gmObj);
+    }
+
+    [Test]
+    public void SpawnHazard_UsesObjectPoolWhenEnabled()
+    {
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("isRunning", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, true);
+
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<HazardSpawner>();
+        spawner.usePooling = true;
+
+        var prefab = new GameObject("prefab");
+        spawner.pitPrefabs = new[] { prefab };
+
+        // Build object pools
+        typeof(HazardSpawner).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(spawner, null);
+        var poolsField = typeof(HazardSpawner).GetField("pools", BindingFlags.NonPublic | BindingFlags.Instance);
+        var pools = (Dictionary<GameObject, ObjectPool>)poolsField.GetValue(spawner);
+        var pool = pools[prefab];
+        pool.initialSize = 1;
+        typeof(ObjectPool).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pool, null);
+
+        // Spawn a hazard from the pool
+        typeof(HazardSpawner).GetMethod("SpawnHazard", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(spawner, null);
+        var spawned = pool.transform.GetChild(0).gameObject;
+
+        Assert.IsTrue(spawned.activeSelf, "Hazard should be activated from the pool");
+        Assert.AreEqual(pool.transform, spawned.transform.parent, "Spawned hazard should stay parented to its pool");
+
+        Object.DestroyImmediate(prefab);
+        Object.DestroyImmediate(spawnerObj);
+        Object.DestroyImmediate(gmObj);
+    }
+}

--- a/Assets/Tests/EditMode/ObjectPoolEdgeTests.cs
+++ b/Assets/Tests/EditMode/ObjectPoolEdgeTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+using System.Collections.Generic;
+
+/// <summary>
+/// Additional unit tests for <see cref="ObjectPool"/> covering less common
+/// scenarios. These tests verify that pools expand when depleted, reuse
+/// returned instances and gracefully handle missing prefabs.
+/// </summary>
+public class ObjectPoolEdgeTests
+{
+    [Test]
+    public void GetObject_ExpandsWhenDepleted()
+    {
+        // Pool starts with a single instance so requesting two should
+        // automatically create an additional object.
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+        pool.initialSize = 1;
+
+        // Manually populate initial objects by invoking Start.
+        typeof(ObjectPool).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pool, null);
+
+        // Dequeue the existing instance then request another.
+        var first = pool.GetObject(Vector3.zero, Quaternion.identity);
+        var second = pool.GetObject(Vector3.one, Quaternion.identity);
+
+        // Two children under the pool indicates it expanded.
+        Assert.AreEqual(2, pool.transform.childCount,
+            "Pool should instantiate a new object when empty");
+
+        Object.DestroyImmediate(first);
+        Object.DestroyImmediate(second);
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(poolGO);
+    }
+
+    [Test]
+    public void GetObject_ReturnsNullWhenPrefabMissing()
+    {
+        // Without a prefab assigned, the pool cannot create objects and
+        // should simply return null.
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+
+        var obj = pool.GetObject(Vector3.zero, Quaternion.identity);
+
+        Assert.IsNull(obj, "GetObject should yield null when no prefab is set");
+        Object.DestroyImmediate(poolGO);
+    }
+
+    [Test]
+    public void ReturnedObject_IsReused()
+    {
+        // After an object is returned it should be provided again on the
+        // next request rather than instantiating a new one.
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+
+        var first = pool.GetObject(Vector3.zero, Quaternion.identity);
+        pool.ReturnObject(first);
+        var second = pool.GetObject(Vector3.zero, Quaternion.identity);
+
+        Assert.AreSame(first, second, "Returned instances must be reused");
+        Object.DestroyImmediate(first);
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(poolGO);
+    }
+}

--- a/Assets/Tests/EditMode/ObstacleSpawnerTests.cs
+++ b/Assets/Tests/EditMode/ObstacleSpawnerTests.cs
@@ -1,0 +1,87 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tests for <see cref="ObstacleSpawner"/> confirming that spawn
+/// rates respond to stage multipliers and that pooled objects are
+/// reused rather than instantiated each time.
+/// </summary>
+public class ObstacleSpawnerTests
+{
+    [Test]
+    public void Update_UsesSpawnMultiplierForTimer()
+    {
+        // GameManager must report the game is running for Update to spawn.
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("isRunning", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, true);
+
+        // Spawner with a single ground obstacle.
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<ObstacleSpawner>();
+        spawner.usePooling = false;
+        spawner.groundObstacles = new[] { new GameObject("prefab") };
+        spawner.spawnInterval = 1f;
+        spawner.spawnMultiplier = 2f; // expect faster spawns
+        spawner.spawnRateCurve = AnimationCurve.Constant(0f, 1f, 1f);
+
+        // Force the timer to trigger spawning immediately.
+        typeof(ObstacleSpawner).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(spawner, 0f);
+
+        spawner.Update();
+
+        float timer = (float)typeof(ObstacleSpawner).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(spawner);
+
+        // With multiplier 2 the next spawn should occur in half the interval.
+        Assert.AreEqual(0.5f, timer, 0.0001f,
+            "Spawn timer should be divided by the multiplier when greater than 1");
+
+        Object.DestroyImmediate(spawner.groundObstacles[0]);
+        Object.DestroyImmediate(spawnerObj);
+        Object.DestroyImmediate(gmObj);
+    }
+
+    [Test]
+    public void Spawn_UsesObjectPoolWhenEnabled()
+    {
+        // Setup running GameManager like before.
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("isRunning", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, true);
+
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<ObstacleSpawner>();
+        spawner.usePooling = true;
+
+        var prefab = new GameObject("prefab");
+        spawner.groundObstacles = new[] { prefab };
+
+        // Initialize internal object pools
+        typeof(ObstacleSpawner).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(spawner, null);
+        var poolsField = typeof(ObstacleSpawner).GetField("pools", BindingFlags.NonPublic | BindingFlags.Instance);
+        var pools = (Dictionary<GameObject, ObjectPool>)poolsField.GetValue(spawner);
+        var pool = pools[prefab];
+        pool.initialSize = 1;
+        typeof(ObjectPool).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pool, null);
+
+        // Invoke spawn and ensure an instance from the pool was used.
+        typeof(ObstacleSpawner).GetMethod("Spawn", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(spawner, null);
+        var spawned = pool.transform.GetChild(0).gameObject;
+
+        Assert.IsTrue(spawned.activeSelf, "Object should be activated when spawned from the pool");
+        Assert.AreEqual(pool.transform, spawned.transform.parent, "Spawned instance should remain parented to its pool");
+
+        Object.DestroyImmediate(prefab);
+        Object.DestroyImmediate(spawnerObj);
+        Object.DestroyImmediate(gmObj);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ObjectPoolEdgeTests` to cover expansion and null returns
- add `ObstacleSpawnerTests` for spawn multiplier behavior and pooling
- add `HazardSpawnerTests` verifying spawn timing and pooling

## Testing
- `git status --short`