### PR TITLE
Add contextual tutorial system with save slots

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -232,6 +232,7 @@ public class PlayerController : MonoBehaviour
         // Allow jumping while grounded, during the coyote window, or if an extra jump remains.
         if (isGrounded || coyoteTimer > 0f || jumpsRemaining > 0)
         {
+            TutorialManager.Instance?.RegisterJump();
             rb.velocity = new Vector2(rb.velocity.x, 0f);
             rb.AddForce(Vector2.up * jumpForce);
             isJumping = true;
@@ -258,6 +259,7 @@ public class PlayerController : MonoBehaviour
     {
         if (!isSliding)
         {
+            TutorialManager.Instance?.RegisterSlide();
             isSliding = true;
             slideTimer = slideDuration;
             coll.size = new Vector2(colliderSize.x, colliderSize.y / 2f);

--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -43,11 +43,14 @@ public class SaveGameManager : MonoBehaviour
         public float musicVolume = 1f;   // range 0-1
         public float effectsVolume = 1f; // range 0-1
         public string language = "en";   // language code
+        public bool tutorialCompleted;   // has the intro tutorial been shown
+        public bool jumpTipShown;        // has the jump tip been displayed
+        public bool slideTipShown;       // has the slide tip been displayed
         public List<UpgradeEntry> upgrades = new List<UpgradeEntry>();
     }
 
     // Version value written to disk alongside <see cref="SaveData"/>.
-    private const int CurrentVersion = 2;
+    private const int CurrentVersion = 3;
 
     private const string CoinsKey = "ShopCoins";       // legacy PlayerPrefs key
     private const string UpgradePrefix = "UpgradeLevel_"; // legacy PlayerPrefs prefix
@@ -63,7 +66,8 @@ public class SaveGameManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
-            savePath = Path.Combine(Application.persistentDataPath, "savegame.json");
+            // Use the SaveSlotManager so each profile writes to its own file
+            savePath = SaveSlotManager.GetPath("savegame.json");
             LoadData();
         }
         else
@@ -131,6 +135,39 @@ public class SaveGameManager : MonoBehaviour
         }
     }
 
+    /// <summary>True once the introductory tutorial has been completed.</summary>
+    public bool TutorialCompleted
+    {
+        get => data.tutorialCompleted;
+        set
+        {
+            data.tutorialCompleted = value;
+            SaveDataToFile();
+        }
+    }
+
+    /// <summary>Whether the jump hint has already been shown.</summary>
+    public bool JumpTipShown
+    {
+        get => data.jumpTipShown;
+        set
+        {
+            data.jumpTipShown = value;
+            SaveDataToFile();
+        }
+    }
+
+    /// <summary>Whether the slide hint has already been shown.</summary>
+    public bool SlideTipShown
+    {
+        get => data.slideTipShown;
+        set
+        {
+            data.slideTipShown = value;
+            SaveDataToFile();
+        }
+    }
+
     /// <summary>Returns the purchased level count for an upgrade.</summary>
     public int GetUpgradeLevel(UpgradeType type)
     {
@@ -169,12 +206,21 @@ public class SaveGameManager : MonoBehaviour
                     {
                         loaded.language = "en";
                     }
+                    if (loaded.version < 3)
+                    {
+                        loaded.tutorialCompleted = false;
+                        loaded.jumpTipShown = false;
+                        loaded.slideTipShown = false;
+                    }
 
                     data.coins = loaded.coins;
                     data.highScore = loaded.highScore;
                     data.musicVolume = Mathf.Clamp01(loaded.musicVolume);
                     data.effectsVolume = Mathf.Clamp01(loaded.effectsVolume);
                     data.language = loaded.language ?? "en";
+                    data.tutorialCompleted = loaded.tutorialCompleted;
+                    data.jumpTipShown = loaded.jumpTipShown;
+                    data.slideTipShown = loaded.slideTipShown;
                     LocalizationManager.SetLanguage(data.language);
                     
                     upgradeLevels.Clear();
@@ -203,6 +249,9 @@ public class SaveGameManager : MonoBehaviour
             data.musicVolume = 1f;
             data.effectsVolume = 1f;
             data.language = "en";
+            data.tutorialCompleted = PlayerPrefs.GetInt("TutorialSeen", 0) == 1;
+            data.jumpTipShown = false;
+            data.slideTipShown = false;
             foreach (UpgradeType type in Enum.GetValues(typeof(UpgradeType)))
             {
                 int level = PlayerPrefs.GetInt(UpgradePrefix + type, 0);

--- a/Assets/Scripts/SaveSlotManager.cs
+++ b/Assets/Scripts/SaveSlotManager.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Manages the currently selected save slot. Each slot stores game data in a
+/// separate folder under <see cref="Application.persistentDataPath"/> so multiple
+/// player profiles can exist on the same machine. The selected slot index is
+/// persisted via <see cref="PlayerPrefs"/>.
+/// </summary>
+public static class SaveSlotManager
+{
+    /// <summary>Maximum number of available save slots.</summary>
+    public const int MaxSlots = 3;
+
+    /// <summary>Preference key storing the active slot index.</summary>
+    private const string SlotPref = "CurrentSaveSlot";
+
+    /// <summary>Index of the slot currently in use.</summary>
+    public static int CurrentSlot { get; private set; }
+
+    static SaveSlotManager()
+    {
+        CurrentSlot = Mathf.Clamp(PlayerPrefs.GetInt(SlotPref, 0), 0, MaxSlots - 1);
+    }
+
+    /// <summary>
+    /// Changes the active slot and persists the choice. Throws when an invalid
+    /// index is provided.
+    /// </summary>
+    /// <param name="slot">Value between 0 and <see cref="MaxSlots"/> - 1.</param>
+    public static void SetSlot(int slot)
+    {
+        if (slot < 0 || slot >= MaxSlots)
+        {
+            throw new ArgumentOutOfRangeException(nameof(slot), "Invalid save slot index");
+        }
+        CurrentSlot = slot;
+        PlayerPrefs.SetInt(SlotPref, slot);
+        PlayerPrefs.Save();
+    }
+
+    /// <summary>
+    /// Returns a path inside the current slot's directory for the given file
+    /// name. The directory is created if it does not already exist.
+    /// </summary>
+    public static string GetPath(string fileName)
+    {
+        string dir = Path.Combine(Application.persistentDataPath, $"slot_{CurrentSlot}");
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+        return Path.Combine(dir, fileName);
+    }
+}
+

--- a/Assets/Scripts/SettingsMenu.cs
+++ b/Assets/Scripts/SettingsMenu.cs
@@ -20,6 +20,9 @@ public class SettingsMenu : MonoBehaviour
     public Dropdown languageDropdown;
     public Toggle rumbleToggle;
 
+    [Tooltip("Tutorial manager used to show help panels.")]
+    public TutorialManager tutorialManager;
+
     /// <summary>
     /// Populates UI elements with the current settings on start.
     /// </summary>
@@ -199,6 +202,18 @@ public class SettingsMenu : MonoBehaviour
         {
             string fmt = LocalizationManager.Get("percentage_format");
             effectsVolumeLabel.text = string.Format(fmt, Mathf.RoundToInt(value * 100f));
+        }
+    }
+
+    /// <summary>
+    /// Shows the tutorial sequence again as a help reference.
+    /// </summary>
+    public void ShowHelp()
+    {
+        if (tutorialManager != null)
+        {
+            tutorialManager.gameObject.SetActive(true);
+            tutorialManager.BeginTutorial();
         }
     }
 }

--- a/Assets/Scripts/TutorialManager.cs
+++ b/Assets/Scripts/TutorialManager.cs
@@ -2,20 +2,37 @@ using UnityEngine;
 
 /// <summary>
 /// Simple first-run tutorial system displaying a sequence of panels. The
-/// tutorial pauses gameplay while active and marks completion in PlayerPrefs so
-/// it only appears once unless manually restarted.
+/// tutorial pauses gameplay while active and marks completion in the save file
+/// so it only appears once per player profile unless manually restarted.
 /// </summary>
 public class TutorialManager : MonoBehaviour
 {
     [Tooltip("Ordered list of tutorial panels shown to the player.")]
     public GameObject[] tutorialPanels;
 
+    [Tooltip("Panel displayed after the player performs their first jump.")]
+    public GameObject jumpTipPanel;
+
+    [Tooltip("Panel displayed after the player performs their first slide.")]
+    public GameObject slideTipPanel;
+
+    public static TutorialManager Instance { get; private set; }
+
     private int index;
     private const string SeenKey = "TutorialSeen";
 
+    void Awake()
+    {
+        Instance = this;
+    }
+
     void Start()
     {
-        if (PlayerPrefs.GetInt(SeenKey, 0) == 0)
+        bool seen = SaveGameManager.Instance != null
+            ? SaveGameManager.Instance.TutorialCompleted
+            : PlayerPrefs.GetInt(SeenKey, 0) == 1;
+
+        if (!seen)
         {
             BeginTutorial();
         }
@@ -68,9 +85,57 @@ public class TutorialManager : MonoBehaviour
     // Finishes the tutorial and resumes normal time scale.
     private void EndTutorial()
     {
-        PlayerPrefs.SetInt(SeenKey, 1);
+        if (SaveGameManager.Instance != null)
+        {
+            SaveGameManager.Instance.TutorialCompleted = true;
+        }
+        PlayerPrefs.SetInt(SeenKey, 1); // legacy fallback
         PlayerPrefs.Save();
         Time.timeScale = 1f;
         gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Triggered after the player's first jump. Shows the jump tip panel if it
+    /// has not been displayed for the current profile.
+    /// </summary>
+    public void RegisterJump()
+    {
+        if (jumpTipPanel == null || SaveGameManager.Instance == null)
+            return;
+        if (!SaveGameManager.Instance.JumpTipShown)
+        {
+            SaveGameManager.Instance.JumpTipShown = true;
+            PauseAndShow(jumpTipPanel);
+        }
+    }
+
+    /// <summary>
+    /// Triggered after the player's first slide to display the slide tip panel.
+    /// </summary>
+    public void RegisterSlide()
+    {
+        if (slideTipPanel == null || SaveGameManager.Instance == null)
+            return;
+        if (!SaveGameManager.Instance.SlideTipShown)
+        {
+            SaveGameManager.Instance.SlideTipShown = true;
+            PauseAndShow(slideTipPanel);
+        }
+    }
+
+    /// <summary>Hides the provided tip panel and resumes time.</summary>
+    public void CloseTip(GameObject panel)
+    {
+        if (panel != null)
+            panel.SetActive(false);
+        Time.timeScale = 1f;
+    }
+
+    // Helper to pause the game and activate a tip panel.
+    private void PauseAndShow(GameObject panel)
+    {
+        Time.timeScale = 0f;
+        panel.SetActive(true);
     }
 }

--- a/Assets/Tests/EditMode/TutorialManagerTests.cs
+++ b/Assets/Tests/EditMode/TutorialManagerTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
+using System.IO;
 
 /// <summary>
 /// EditMode tests for <see cref="TutorialManager"/> verifying that the tutorial
@@ -15,6 +16,14 @@ public class TutorialManagerTests
         // Ensure each test starts with a clean PlayerPrefs state and normal time.
         PlayerPrefs.DeleteAll();
         Time.timeScale = 1f;
+        for (int i = 0; i < SaveSlotManager.MaxSlots; i++)
+        {
+            string dir = Path.Combine(Application.persistentDataPath, $"slot_{i}");
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+        }
     }
 
     [Test]
@@ -94,5 +103,90 @@ public class TutorialManagerTests
 
         Object.DestroyImmediate(obj);
         Object.DestroyImmediate(panel);
+    }
+
+    [Test]
+    public void Tutorial_TriggersPerSaveSlot()
+    {
+        // Slot 0 should show the tutorial the first time.
+        SaveSlotManager.SetSlot(0);
+        var saveObj = new GameObject("save0");
+        saveObj.AddComponent<SaveGameManager>();
+
+        var obj = new GameObject("tm");
+        var tm = obj.AddComponent<TutorialManager>();
+        var panel = new GameObject("panel");
+        tm.tutorialPanels = new[] { panel };
+
+        typeof(TutorialManager).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(tm, null);
+        Assert.IsTrue(panel.activeSelf);
+        tm.Next();
+        Object.DestroyImmediate(obj);
+        Object.DestroyImmediate(panel);
+        Object.DestroyImmediate(saveObj);
+
+        // Same slot should skip on next load.
+        SaveSlotManager.SetSlot(0);
+        var saveObj2 = new GameObject("save1");
+        saveObj2.AddComponent<SaveGameManager>();
+        var obj2 = new GameObject("tm2");
+        var tm2 = obj2.AddComponent<TutorialManager>();
+        var panel2 = new GameObject("panel2");
+        tm2.tutorialPanels = new[] { panel2 };
+        typeof(TutorialManager).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(tm2, null);
+        Assert.IsFalse(obj2.activeSelf);
+        Object.DestroyImmediate(obj2);
+        Object.DestroyImmediate(panel2);
+        Object.DestroyImmediate(saveObj2);
+
+        // Slot 1 is a fresh profile so tutorial should show again.
+        SaveSlotManager.SetSlot(1);
+        var saveObj3 = new GameObject("save2");
+        saveObj3.AddComponent<SaveGameManager>();
+        var obj3 = new GameObject("tm3");
+        var tm3 = obj3.AddComponent<TutorialManager>();
+        var panel3 = new GameObject("panel3");
+        tm3.tutorialPanels = new[] { panel3 };
+        typeof(TutorialManager).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(tm3, null);
+        Assert.IsTrue(panel3.activeSelf);
+        Object.DestroyImmediate(obj3);
+        Object.DestroyImmediate(panel3);
+        Object.DestroyImmediate(saveObj3);
+    }
+
+    [Test]
+    public void ContextTips_ShowOnlyOnce()
+    {
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+
+        var obj = new GameObject("tm");
+        var tm = obj.AddComponent<TutorialManager>();
+        var jump = new GameObject("jump");
+        var slide = new GameObject("slide");
+        jump.SetActive(false);
+        slide.SetActive(false);
+        tm.jumpTipPanel = jump;
+        tm.slideTipPanel = slide;
+
+        tm.RegisterJump();
+        Assert.IsTrue(jump.activeSelf);
+        tm.CloseTip(jump);
+        tm.RegisterJump();
+        Assert.IsFalse(jump.activeSelf);
+
+        tm.RegisterSlide();
+        Assert.IsTrue(slide.activeSelf);
+        tm.CloseTip(slide);
+        tm.RegisterSlide();
+        Assert.IsFalse(slide.activeSelf);
+
+        Object.DestroyImmediate(obj);
+        Object.DestroyImmediate(jump);
+        Object.DestroyImmediate(slide);
+        Object.DestroyImmediate(saveObj);
     }
 }


### PR DESCRIPTION
## Summary
- create `SaveSlotManager` for multi-profile saves
- extend `SaveGameManager` with tutorial and tip flags
- update `TutorialManager` for per-profile storage and context tips
- hook tutorial tips from `PlayerController`
- open tutorials from settings via help option
- add tests for slot handling and tip behaviour

## Testing
- `npm test`