### PR TITLE
Add double jump and invincibility power-ups

### DIFF
--- a/Assets/Scripts/DailyChallengeManager.cs
+++ b/Assets/Scripts/DailyChallengeManager.cs
@@ -14,7 +14,17 @@ public class DailyChallengeManager : MonoBehaviour
     public enum ChallengeType { Distance, Coins, PowerUpUse }
 
     /// <summary>Supported power-up identifiers for power-up challenges.</summary>
-    public enum PowerUpType { Magnet, SpeedBoost, Shield, GravityFlip, SlowMotion, CoinBonus }
+    public enum PowerUpType
+    {
+        Magnet,
+        SpeedBoost,
+        Shield,
+        GravityFlip,
+        SlowMotion,
+        CoinBonus,
+        DoubleJump,
+        Invincibility
+    }
 
     [Serializable]
     private class ChallengeState

--- a/Assets/Scripts/DoubleJumpPowerUp.cs
+++ b/Assets/Scripts/DoubleJumpPowerUp.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+/// <summary>
+/// Grants the player an additional air jump for a limited time when collected.
+/// Duration can be extended via the shop upgrade of type <see cref="UpgradeType.DoubleJumpDuration"/>.
+/// </summary>
+public class DoubleJumpPowerUp : MonoBehaviour
+{
+    [Tooltip("Seconds the double jump ability lasts after pickup.")]
+    public float duration = 5f;
+
+    [Tooltip("Sound played when the power-up is collected.")]
+    public AudioClip collectClip;
+
+    [Tooltip("Optional effect spawned at the player's position on activation.")]
+    public GameObject pickupEffect;
+
+    /// <summary>
+    /// Activates the double jump ability for the player when they collide with this power-up.
+    /// </summary>
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            PlayerController pc = other.GetComponent<PlayerController>();
+            if (pc != null)
+            {
+                float total = duration;
+                if (ShopManager.Instance != null)
+                {
+                    total += ShopManager.Instance.GetUpgradeEffect(UpgradeType.DoubleJumpDuration);
+                }
+                pc.ActivateDoubleJump(total);
+
+                // Notify the daily challenge system of usage.
+                if (DailyChallengeManager.Instance != null)
+                {
+                    DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.DoubleJump);
+                }
+            }
+
+            if (pickupEffect != null)
+            {
+                Instantiate(pickupEffect, other.transform.position, Quaternion.identity);
+            }
+            if (AudioManager.Instance != null)
+            {
+                AudioManager.Instance.PlaySound(collectClip);
+            }
+            InputManager.TriggerRumble(0.3f, 0.1f);
+
+            PooledObject po = GetComponent<PooledObject>();
+            if (po != null && po.Pool != null)
+            {
+                po.Pool.ReturnObject(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/InvincibilityPowerUp.cs
+++ b/Assets/Scripts/InvincibilityPowerUp.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+
+/// <summary>
+/// Provides temporary invulnerability identical to <see cref="PlayerShield"/> but
+/// themed as a separate power-up. Duration scales with the
+/// <see cref="UpgradeType.InvincibilityDuration"/> shop upgrade.
+/// </summary>
+public class InvincibilityPowerUp : MonoBehaviour
+{
+    [Tooltip("Seconds the player remains invulnerable after pickup.")]
+    public float duration = 5f;
+
+    [Tooltip("Clip played upon collection.")]
+    public AudioClip collectClip;
+
+    [Tooltip("Optional visual effect prefab spawned when activated.")]
+    public GameObject pickupEffect;
+
+    /// <summary>
+    /// Grants invulnerability when the player collides with this power-up.
+    /// </summary>
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            PlayerShield shield = other.GetComponent<PlayerShield>();
+            if (shield != null)
+            {
+                float total = duration;
+                if (ShopManager.Instance != null)
+                {
+                    total += ShopManager.Instance.GetUpgradeEffect(UpgradeType.InvincibilityDuration);
+                }
+                shield.ActivateShield(total);
+                if (DailyChallengeManager.Instance != null)
+                {
+                    DailyChallengeManager.Instance.RecordPowerUpUse(DailyChallengeManager.PowerUpType.Invincibility);
+                }
+            }
+
+            if (pickupEffect != null)
+            {
+                Instantiate(pickupEffect, other.transform.position, Quaternion.identity);
+            }
+            if (AudioManager.Instance != null)
+            {
+                AudioManager.Instance.PlaySound(collectClip);
+            }
+            InputManager.TriggerRumble(0.3f, 0.1f);
+
+            PooledObject po = GetComponent<PooledObject>();
+            if (po != null && po.Pool != null)
+            {
+                po.Pool.ReturnObject(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -11,7 +11,8 @@ using UnityEngine;
 /// gravity scaling, an optional fast-fall when holding the down key, an air dash
 /// triggered by sliding with horizontal input, and slide canceling so releasing
 /// the key ends the move immediately. These tweaks keep jumps snappy and give
-/// the player crisp mid-air control.
+/// the player crisp mid-air control. Support for <see cref="DoubleJumpPowerUp"/>
+/// adds a temporary extra jump timer handled by this controller.
 /// </summary>
 public class PlayerController : MonoBehaviour
 {
@@ -66,6 +67,10 @@ public class PlayerController : MonoBehaviour
     private float slideBufferTimer;
     private bool airDivePending;
     private float dashTimer;
+    // Duration the extra air jump ability remains active.
+    private float doubleJumpTimer;
+    // Base number of air jumps normally allowed.
+    private const int BaseAirJumps = 1;
 
     /// <summary>
     /// Caches component references used for controlling the character.
@@ -81,6 +86,7 @@ public class PlayerController : MonoBehaviour
         slideBufferTimer = 0f;
         airDivePending = false;
         dashTimer = 0f;
+        doubleJumpTimer = 0f;
     }
 
     /// <summary>
@@ -98,6 +104,10 @@ public class PlayerController : MonoBehaviour
         if (dashTimer > 0f)
         {
             dashTimer -= Time.deltaTime;
+        }
+        if (doubleJumpTimer > 0f)
+        {
+            doubleJumpTimer -= Time.deltaTime;
         }
 
         // Handle jump input and variable jump height using custom bindings
@@ -197,7 +207,7 @@ public class PlayerController : MonoBehaviour
     /// <summary>
     /// Uses a raycast to determine if the player is touching a surface in the
     /// current gravity direction. Also manages the coyote-time grace period and
-    /// available double jump.
+    /// available air jumps including those from <see cref="DoubleJumpPowerUp"/>.
     /// </summary>
     void CheckGrounded()
     {
@@ -209,11 +219,12 @@ public class PlayerController : MonoBehaviour
         isGrounded = hit.collider != null;
         if (isGrounded)
         {
-            // Reset coyote timer and available jumps when touching the ground
+            // Reset coyote timer and available jumps when touching the ground.
             coyoteTimer = coyoteTime;
             if (!wasGrounded)
             {
-                jumpsRemaining = 1; // allow one extra jump in air
+                int extra = doubleJumpTimer > 0f ? 1 : 0;
+                jumpsRemaining = BaseAirJumps + extra;
             }
         }
         else
@@ -225,7 +236,7 @@ public class PlayerController : MonoBehaviour
 
     /// <summary>
     /// Executes a jump if conditions are met. Supports coyote time and
-    /// a single air jump.
+    /// extra air jumps granted by <see cref="DoubleJumpPowerUp"/>.
     /// </summary>
     void AttemptJump()
     {
@@ -355,6 +366,21 @@ public class PlayerController : MonoBehaviour
             {
                 GameManager.Instance.GameOver();
             }
+        }
+    }
+
+    /// <summary>
+    /// Enables an additional mid-air jump for a limited time.
+    /// </summary>
+    public void ActivateDoubleJump(float duration)
+    {
+        if (duration <= 0f)
+            throw new System.ArgumentException("duration must be positive", nameof(duration));
+
+        doubleJumpTimer = duration;
+        if (isGrounded)
+        {
+            jumpsRemaining = BaseAirJumps + 1;
         }
     }
 }

--- a/Assets/Scripts/UpgradeType.cs
+++ b/Assets/Scripts/UpgradeType.cs
@@ -27,5 +27,11 @@ public enum UpgradeType
     StartingPowerUp = 5,
 
     /// <summary>Extends the duration of the coin bonus power-up.</summary>
-    CoinBonusDuration = 6
+    CoinBonusDuration = 6,
+
+    /// <summary>Additional seconds the <see cref="DoubleJumpPowerUp"/> remains active.</summary>
+    DoubleJumpDuration = 7,
+
+    /// <summary>Additional seconds applied to <see cref="InvincibilityPowerUp"/>.</summary>
+    InvincibilityDuration = 8
 }

--- a/Assets/Tests/EditMode/DoubleJumpPowerUpTests.cs
+++ b/Assets/Tests/EditMode/DoubleJumpPowerUpTests.cs
@@ -1,0 +1,76 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests ensuring <see cref="DoubleJumpPowerUp"/> correctly grants an extra air jump
+/// and respects shop upgrade duration bonuses.
+/// </summary>
+public class DoubleJumpPowerUpTests
+{
+    [Test]
+    public void OnTriggerEnter_ActivatesDoubleJumpWithUpgrade()
+    {
+        // Setup save and shop so upgrade values can be applied
+        System.IO.File.Delete(System.IO.Path.Combine(
+            Application.persistentDataPath, "savegame.json"));
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+
+        var data = new ShopManager.UpgradeData { type = UpgradeType.DoubleJumpDuration, cost = 1, effect = 1f };
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (System.Collections.Generic.Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.DoubleJumpDuration] = 1;
+        dictField.SetValue(sm, levels);
+
+        // Player with controller component
+        var player = new GameObject("player");
+        player.tag = "Player";
+        var pc = player.AddComponent<PlayerController>();
+        player.AddComponent<CapsuleCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var dj = powerObj.AddComponent<DoubleJumpPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+        dj.duration = 2f;
+
+        dj.OnTriggerEnter2D(player.GetComponent<CapsuleCollider2D>());
+
+        FieldInfo timerField = typeof(PlayerController).GetField("doubleJumpTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(pc);
+
+        // Base duration (2s) plus 1s from the upgrade
+        Assert.AreEqual(3f, timer);
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(shopObj);
+        Object.DestroyImmediate(saveObj);
+    }
+
+    [Test]
+    public void ActivateDoubleJump_DecrementsOverTime()
+    {
+        var player = new GameObject("player");
+        var pc = player.AddComponent<PlayerController>();
+        player.AddComponent<CapsuleCollider2D>();
+
+        pc.ActivateDoubleJump(1f);
+
+        // Call Update twice to simulate time passing
+        pc.Update();
+        typeof(PlayerController).GetField("doubleJumpTimer", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(pc, 0.5f);
+        pc.Update();
+
+        FieldInfo timerField = typeof(PlayerController).GetField("doubleJumpTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(pc);
+        Assert.Less(timer, 0.5f);
+
+        Object.DestroyImmediate(player);
+    }
+}

--- a/Assets/Tests/EditMode/InvincibilityPowerUpTests.cs
+++ b/Assets/Tests/EditMode/InvincibilityPowerUpTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests covering <see cref="InvincibilityPowerUp"/> behaviour.
+/// </summary>
+public class InvincibilityPowerUpTests
+{
+    [Test]
+    public void OnTriggerEnter_DurationIncludesUpgrade()
+    {
+        System.IO.File.Delete(System.IO.Path.Combine(
+            Application.persistentDataPath, "savegame.json"));
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+
+        var data = new ShopManager.UpgradeData { type = UpgradeType.InvincibilityDuration, cost = 1, effect = 1f };
+        var shopObj = new GameObject("shop");
+        var sm = shopObj.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[] { data };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(sm, null);
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (System.Collections.Generic.Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.InvincibilityDuration] = 2;
+        dictField.SetValue(sm, levels);
+
+        var player = new GameObject("player");
+        player.tag = "Player";
+        var shield = player.AddComponent<PlayerShield>();
+        var playerCol = player.AddComponent<BoxCollider2D>();
+
+        var powerObj = new GameObject("power");
+        var inv = powerObj.AddComponent<InvincibilityPowerUp>();
+        var powerCol = powerObj.AddComponent<BoxCollider2D>();
+        powerCol.isTrigger = true;
+        inv.duration = 1f;
+
+        inv.OnTriggerEnter2D(playerCol);
+
+        var timerField = typeof(PlayerShield).GetField("shieldTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(shield);
+        // Total time = base (1s) + 2 upgrade seconds = 3s
+        Assert.AreEqual(3f, timer);
+
+        Object.DestroyImmediate(powerObj);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(shopObj);
+        Object.DestroyImmediate(saveObj);
+    }
+
+    [Test]
+    public void ActivateShield_TimerCountsDown()
+    {
+        var player = new GameObject("player");
+        var shield = player.AddComponent<PlayerShield>();
+
+        shield.ActivateShield(1f);
+        typeof(PlayerShield).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(shield, null);
+        typeof(PlayerShield).GetField("shieldTimer", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(shield, 0.5f);
+        typeof(PlayerShield).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(shield, null);
+
+        var timerField = typeof(PlayerShield).GetField("shieldTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+        float timer = (float)timerField.GetValue(shield);
+        Assert.Less(timer, 0.5f);
+
+        Object.DestroyImmediate(player);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DoubleJumpPowerUp` and `InvincibilityPowerUp`
- extend `PlayerController` with double-jump ability timer
- support new upgrade types and daily challenge enums
- add unit tests for both new power-ups

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -logFile test.log -quit` *(fails: command not found)*