### PR TITLE
Add combo-aware difficulty scaling

### DIFF
--- a/Assets/Scripts/AdaptiveDifficultyManager.cs
+++ b/Assets/Scripts/AdaptiveDifficultyManager.cs
@@ -1,10 +1,21 @@
 using UnityEngine;
 
+/*
+ * 2024 patch summary:
+ * - Difficulty scaling now also considers the player's highest coin combo from
+ *   the previous run via GameManager.
+ * - A small bonus multiplier is applied for high combos to reward skilled
+ *   coin collection with slightly tougher spawns.
+ */
+
 /// <summary>
 /// Adjusts obstacle and hazard spawn rates based on the player's recent
 /// performance. The manager queries <see cref="AnalyticsManager"/> for the
 /// average distance of the last few runs and scales spawner multipliers so
 /// difficulty increases for skilled players and eases off when runs end early.
+/// A 2024 revision also factors in the highest coin combo achieved in the last
+/// session via <see cref="GameManager"/> allowing skilled play to nudge the
+/// difficulty upward.
 /// </summary>
 public class AdaptiveDifficultyManager : MonoBehaviour
 {
@@ -29,6 +40,11 @@ public class AdaptiveDifficultyManager : MonoBehaviour
     public float maxMultiplier = 2f;
 
     private float currentMultiplier = 1f;
+
+    // Bonus applied for each additional combo multiplier level. For example
+    // a value of 0.05f means a combo of x3 increases the multiplier by
+    // 10% (1 + (3 - 1) * 0.05).
+    private const float comboBonusStep = 0.05f;
 
     private ObstacleSpawner obstacleSpawner;
     private HazardSpawner hazardSpawner;
@@ -78,6 +94,18 @@ public class AdaptiveDifficultyManager : MonoBehaviour
         {
             currentMultiplier = Mathf.Max(minMultiplier, currentMultiplier - decreaseStep);
         }
+
+        // Factor in the player's coin combo performance from the last run. A
+        // high combo implies the player consistently collects coins, so the
+        // difficulty can scale up slightly faster. The bonus is clamped using
+        // the configured min/max bounds to avoid runaway values.
+        int combo = 1;
+        if (GameManager.Instance != null)
+        {
+            combo = Mathf.Max(1, GameManager.Instance.GetCoinComboMultiplier());
+        }
+        float comboMult = 1f + (combo - 1) * comboBonusStep;
+        currentMultiplier = Mathf.Clamp(currentMultiplier * comboMult, minMultiplier, maxMultiplier);
 
         if (obstacleSpawner != null)
             obstacleSpawner.spawnMultiplier = currentMultiplier;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -19,6 +19,12 @@ using System.Collections;
 /// methods so UI elements can display the remaining time. A new hardcore
 /// mode option further increases game speed and spawn rates for an extra
 /// challenge.
+///
+/// <remarks>
+/// 2024 update: exposes <see cref="GetCoinComboMultiplier"/> so external
+/// systems such as <see cref="AdaptiveDifficultyManager"/> can react to the
+/// player's combo performance.
+/// </remarks>
 /// 
 /// <remarks>
 /// 2024 update: starting a run now triggers <see cref="AdaptiveDifficultyManager"/>
@@ -632,6 +638,16 @@ public class GameManager : MonoBehaviour
     public int GetCurrentStage()
     {
         return currentStage;
+    }
+
+    /// <summary>
+    /// Current coin combo multiplier. Returns one when no combo is
+    /// active so callers can easily scale rewards based on the combo
+    /// state.
+    /// </summary>
+    public int GetCoinComboMultiplier()
+    {
+        return coinComboMultiplier;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/AdaptiveDifficultyManagerTests.cs
+++ b/Assets/Tests/EditMode/AdaptiveDifficultyManagerTests.cs
@@ -72,6 +72,83 @@ public class AdaptiveDifficultyManagerTests
         Object.DestroyImmediate(analyticsObj);
     }
 
+    /// <summary>
+    /// Ensures a high coin combo from the previous run slightly
+    /// increases spawn multipliers even when distance is average.
+    /// </summary>
+    [Test]
+    public void AdjustDifficulty_IncludesComboBonus()
+    {
+        var analyticsObj = new GameObject("am");
+        var am = analyticsObj.AddComponent<AnalyticsManager>();
+        am.LogRun(500f, 0, true); // at target distance
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("coinComboMultiplier", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, 5); // simulate high combo
+
+        var obstacleObj = new GameObject("obs");
+        var obstacle = obstacleObj.AddComponent<ObstacleSpawner>();
+        var hazardObj = new GameObject("haz");
+        var hazard = hazardObj.AddComponent<HazardSpawner>();
+
+        var diffObj = new GameObject("diff");
+        var diff = diffObj.AddComponent<AdaptiveDifficultyManager>();
+        diff.targetDistance = 500f;
+        diff.RegisterSpawners(obstacle, hazard);
+        diff.AdjustDifficulty();
+
+        float expected = 1f + (5 - 1) * 0.05f;
+        Assert.AreEqual(expected, obstacle.spawnMultiplier, 0.0001f,
+            "Combo multiplier should add a small bonus to the spawn multiplier");
+        Assert.AreEqual(expected, hazard.spawnMultiplier, 0.0001f);
+
+        Object.DestroyImmediate(diffObj);
+        Object.DestroyImmediate(obstacleObj);
+        Object.DestroyImmediate(hazardObj);
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(analyticsObj);
+    }
+
+    /// <summary>
+    /// Verifies combo scaling respects the max multiplier limit.
+    /// </summary>
+    [Test]
+    public void AdjustDifficulty_ComboBonusClampedByMax()
+    {
+        var analyticsObj = new GameObject("am");
+        var am = analyticsObj.AddComponent<AnalyticsManager>();
+        am.LogRun(500f, 0, true);
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("coinComboMultiplier", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, 20); // extremely high combo
+
+        var obstacleObj = new GameObject("obs");
+        var obstacle = obstacleObj.AddComponent<ObstacleSpawner>();
+        var hazardObj = new GameObject("haz");
+        var hazard = hazardObj.AddComponent<HazardSpawner>();
+
+        var diffObj = new GameObject("diff");
+        var diff = diffObj.AddComponent<AdaptiveDifficultyManager>();
+        diff.targetDistance = 500f;
+        diff.maxMultiplier = 1.1f; // tight upper bound
+        diff.RegisterSpawners(obstacle, hazard);
+        diff.AdjustDifficulty();
+
+        Assert.AreEqual(1.1f, obstacle.spawnMultiplier, 0.0001f,
+            "Multiplier should not exceed configured maximum");
+        Assert.AreEqual(1.1f, hazard.spawnMultiplier, 0.0001f);
+
+        Object.DestroyImmediate(diffObj);
+        Object.DestroyImmediate(obstacleObj);
+        Object.DestroyImmediate(hazardObj);
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(analyticsObj);
+    }
+
     [TearDown]
     public void ResetSingleton()
     {


### PR DESCRIPTION
## Summary
- adjust AdaptiveDifficultyManager to consider coin combo multiplier
- expose coin combo data through GameManager
- test combo-based scaling logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c4434972883218d4f2c4ecb805eb0