### PR TITLE
Add achievement unlock triggers and tests

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -30,6 +30,10 @@ using System.Collections;
 /// 2024 update: starting a run now triggers <see cref="AdaptiveDifficultyManager"/>
 /// so obstacle and hazard spawners scale with player skill.
 /// </remarks>
+/// <remarks>
+/// 2025 update: achievements are now unlocked for high coin combos,
+/// boss defeats and clearing hardcore mode.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -108,6 +112,9 @@ public class GameManager : MonoBehaviour
     private const string AchDistance5000 = "ACH_DISTANCE_5000";
     private const string AchCoins50 = "ACH_COINS_50";
     private const string AchCoins200 = "ACH_COINS_200";
+    private const string AchCombo10 = "ACH_COMBO_10";
+    private const string AchFirstBoss = "ACH_FIRST_BOSS";
+    private const string AchHardcoreWin = "ACH_HARDCORE_WIN";
 
     public static GameManager Instance { get; private set; }
 
@@ -355,6 +362,14 @@ public class GameManager : MonoBehaviour
                 SteamManager.Instance.UnlockAchievement(AchCoins200);
             }
 
+            // Completing a long run in hardcore mode grants an additional
+            // achievement. The distance threshold mirrors the standard
+            // marathon achievement so players must truly master the mode.
+            if (hardcoreMode && finalScore >= 5000)
+            {
+                SteamManager.Instance.UnlockAchievement(AchHardcoreWin);
+            }
+
             // Submit the score to the Steam leaderboard
             SteamManager.Instance.UploadScore(finalScore);
         }
@@ -575,6 +590,14 @@ public class GameManager : MonoBehaviour
             AudioManager.Instance.PlaySound(comboSound, pitch);
         }
 
+        // Unlock the combo achievement once the multiplier reaches the
+        // defined threshold. The SteamManager ignores duplicate unlocks
+        // so this check can run every increase without additional state.
+        if (SteamManager.Instance != null && coinComboMultiplier >= 10)
+        {
+            SteamManager.Instance.UnlockAchievement(AchCombo10);
+        }
+
     }
 
     /// <summary>
@@ -583,6 +606,18 @@ public class GameManager : MonoBehaviour
     public void SetUIManager(UIManager manager)
     {
         uiManager = manager;
+    }
+
+    /// <summary>
+    /// Called by boss entities when defeated so the appropriate Steam
+    /// achievement can be granted.
+    /// </summary>
+    public void NotifyBossDefeated()
+    {
+        if (SteamManager.Instance != null)
+        {
+            SteamManager.Instance.UnlockAchievement(AchFirstBoss);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/SteamManager.cs
+++ b/Assets/Scripts/SteamManager.cs
@@ -24,7 +24,10 @@ public class SteamManager : MonoBehaviour
         { "ACH_DISTANCE_5000", "ach_distance_5000_name" },
         { "ACH_COINS_50", "ach_coins_50_name" },
         { "ACH_COINS_200", "ach_coins_200_name" },
-        { "ACH_DAILY_COMPLETE", "ach_daily_complete_name" }
+        { "ACH_DAILY_COMPLETE", "ach_daily_complete_name" },
+        { "ACH_COMBO_10", "ach_combo_10_name" },
+        { "ACH_FIRST_BOSS", "ach_boss_first_name" },
+        { "ACH_HARDCORE_WIN", "ach_hardcore_win_name" }
     };
 
     private static readonly Dictionary<string, string> achievementDescKeys = new Dictionary<string, string>
@@ -33,7 +36,10 @@ public class SteamManager : MonoBehaviour
         { "ACH_DISTANCE_5000", "ach_distance_5000_desc" },
         { "ACH_COINS_50", "ach_coins_50_desc" },
         { "ACH_COINS_200", "ach_coins_200_desc" },
-        { "ACH_DAILY_COMPLETE", "ach_daily_complete_desc" }
+        { "ACH_DAILY_COMPLETE", "ach_daily_complete_desc" },
+        { "ACH_COMBO_10", "ach_combo_10_desc" },
+        { "ACH_FIRST_BOSS", "ach_boss_first_desc" },
+        { "ACH_HARDCORE_WIN", "ach_hardcore_win_desc" }
     };
 
 #if UNITY_STANDALONE

--- a/Assets/Tests/EditMode/AchievementTriggerTests.cs
+++ b/Assets/Tests/EditMode/AchievementTriggerTests.cs
@@ -1,0 +1,82 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Tests verifying that gameplay events unlock the expected Steam
+/// achievements without requiring the real Steamworks API.
+/// </summary>
+public class AchievementTriggerTests
+{
+    private class DummySteamManager : SteamManager
+    {
+        public System.Collections.Generic.List<string> unlocked = new System.Collections.Generic.List<string>();
+        public override void UnlockAchievement(string id)
+        {
+            unlocked.Add(id);
+        }
+    }
+
+    [Test]
+    public void ComboAchievement_UnlocksAtThreshold()
+    {
+        var steamObj = new GameObject("steam");
+        var steam = steamObj.AddComponent<DummySteamManager>();
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+
+        // Quickly collect coins to raise the combo multiplier to ten
+        for (int i = 0; i < 10; i++)
+        {
+            gm.AddCoins(1);
+        }
+
+        Assert.Contains("ACH_COMBO_10", steam.unlocked);
+
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(steamObj);
+    }
+
+    [Test]
+    public void BossDefeat_TriggersAchievement()
+    {
+        var steamObj = new GameObject("steam");
+        var steam = steamObj.AddComponent<DummySteamManager>();
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+
+        gm.NotifyBossDefeated();
+
+        Assert.Contains("ACH_FIRST_BOSS", steam.unlocked);
+
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(steamObj);
+    }
+
+    [Test]
+    public void HardcoreWin_UnlocksAchievement()
+    {
+        var steamObj = new GameObject("steam");
+        var steam = steamObj.AddComponent<DummySteamManager>();
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+        gm.HardcoreMode = true;
+
+        // Set distance field directly to simulate a long run
+        typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, 6000f);
+        typeof(GameManager).GetField("coins", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, 0);
+
+        gm.GameOver();
+
+        Assert.Contains("ACH_HARDCORE_WIN", steam.unlocked);
+
+        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(steamObj);
+    }
+}


### PR DESCRIPTION
## Summary
- support additional achievements in `SteamManager`
- grant combo, boss and hardcore achievements via `GameManager`
- test achievement triggers with mocked Steam manager

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found)*