### PR TITLE
Handle legacy saves without upgrade list

### DIFF
--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -7,6 +7,10 @@
 // migrated to maintain backward compatibility. Saving writes to a temporary
 // file first to reduce the chance of corruption if the application quits
 // during a write operation.
+//
+// 2025 bug fix: loading no longer throws when the "upgrades" array is missing
+// from a legacy save file. The loader now checks for null before iterating so
+// older saves continue to load correctly.
 // -----------------------------------------------------------------------------
 
 using System;
@@ -241,11 +245,14 @@ public class SaveGameManager : MonoBehaviour
                     LocalizationManager.SetLanguage(data.language);
                     
                     upgradeLevels.Clear();
-                    foreach (var entry in loaded.upgrades)
+                    if (loaded.upgrades != null)
                     {
-                        if (Enum.TryParse(entry.type, out UpgradeType type))
+                        foreach (var entry in loaded.upgrades)
                         {
-                            upgradeLevels[type] = entry.level;
+                            if (Enum.TryParse(entry.type, out UpgradeType type))
+                            {
+                                upgradeLevels[type] = entry.level;
+                            }
                         }
                     }
                     return;

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -127,4 +127,22 @@ public class SaveGameManagerTests
         Assert.AreEqual("es", save2.Language);
         Object.DestroyImmediate(go2);
     }
+
+    [Test]
+    public void MissingUpgrades_DoesNotThrow()
+    {
+        // Simulate an old save file without the upgrades list to ensure
+        // LoadData handles null gracefully after the recent bug fix.
+        string path = Path.Combine(Application.persistentDataPath, "savegame.json");
+        File.WriteAllText(path, "{\"coins\":2,\"highScore\":3}");
+
+        var go = new GameObject("save");
+        var save = go.AddComponent<SaveGameManager>();
+
+        Assert.AreEqual(2, save.Coins);
+        Assert.AreEqual(3, save.HighScore);
+        Assert.AreEqual(0, save.GetUpgradeLevel(UpgradeType.MagnetDuration));
+
+        Object.DestroyImmediate(go);
+    }
 }


### PR DESCRIPTION
## Summary
- fix crash when `SaveGameManager` loads a file without an `upgrades` array
- add regression test covering this case
- document bug fix in `SaveGameManager.cs`

## Testing
- `npm test`