### PR TITLE
Fix rumble and save slot switching

### DIFF
--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -639,6 +639,9 @@ public static class InputManager
         if (rumbleRoutine != null)
             rumbleHost.StopCoroutine(rumbleRoutine);
 
+        // Begin the rumble coroutine which automatically resets after the
+        // specified realtime duration. If another rumble is already active it
+        // is stopped first to avoid overlapping motor control.
         rumbleRoutine = rumbleHost.StartCoroutine(RumbleRoutine(strength, duration));
     }
 
@@ -646,8 +649,11 @@ public static class InputManager
     private static IEnumerator RumbleRoutine(float strength, float duration)
     {
         Gamepad.current.SetMotorSpeeds(strength, strength);
-        yield return new WaitForSeconds(duration);
+        // Wait in realtime so pausing the game doesn't prolong vibration.
+        yield return new WaitForSecondsRealtime(duration);
         Gamepad.current.SetMotorSpeeds(0f, 0f);
+        // Mark the routine as finished so another rumble can start.
+        rumbleRoutine = null;
     }
 
     // Lightweight MonoBehaviour used solely to run coroutines for rumble.

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -321,6 +321,11 @@ public class PlayerController : MonoBehaviour
     void ApplyEnhancedGravity(float deltaTime, bool fastFall)
     {
         Vector2 gravity = Physics2D.gravity;
+        // Avoid NaN results when gravity is effectively zero by skipping
+        // enhanced calculations in that rare case.
+        if (gravity.sqrMagnitude < 0.0001f)
+            return;
+
         Vector2 gravityDir = gravity.normalized;
         float velAlongGravity = Vector2.Dot(rb.velocity, gravityDir);
 

--- a/Assets/Scripts/PlayerShield.cs
+++ b/Assets/Scripts/PlayerShield.cs
@@ -1,8 +1,19 @@
 using UnityEngine;
 
+// -----------------------------------------------------------------------------
+// PlayerShield
+// -----------------------------------------------------------------------------
+// Component that grants temporary invulnerability. When activated the host
+// ignores damage sources until the timer expires or the shield is manually
+// consumed. Attach this to the player character and call ActivateShield from
+// power-up pickups or other gameplay events.
+// -----------------------------------------------------------------------------
 /// <summary>
-/// Handles a temporary invulnerability shield for the player.
-/// When active, collisions with obstacles or hazards are ignored.
+/// Provides a lightweight invulnerability mechanic for the player. While active
+/// the owning GameObject ignores collisions with hazards and obstacles. Typical
+/// usage spawns a visual effect when <see cref="ActivateShield"/> is called and
+/// relies on <see cref="IsActive"/> checks within <see cref="PlayerController"/>
+/// before applying damage.
 /// </summary>
 public class PlayerShield : MonoBehaviour
 {
@@ -11,7 +22,8 @@ public class PlayerShield : MonoBehaviour
     public bool IsActive => shieldTimer > 0f;
 
     /// <summary>
-    /// Counts down the remaining shield duration each frame.
+    /// Decrements the shield timer each frame. Once it reaches zero the shield
+    /// effect ends automatically.
     /// </summary>
     void Update()
     {
@@ -22,10 +34,14 @@ public class PlayerShield : MonoBehaviour
     }
 
     /// <summary>
-    /// Enables the shield for the specified duration in seconds.
+    /// Enables the shield for the specified duration in seconds. Passing a
+    /// non-positive value throws to alert callers of invalid usage.
     /// </summary>
     public void ActivateShield(float duration)
     {
+        if (duration <= 0f)
+            throw new System.ArgumentException("duration must be positive", nameof(duration));
+
         shieldTimer = duration;
     }
 

--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -320,4 +320,25 @@ public class SaveGameManager : MonoBehaviour
         File.Copy(tempPath, savePath, true);
         File.Delete(tempPath);
     }
+
+    /// <summary>
+    /// Switches to a different save slot at runtime. The current data is
+    /// written to disk before swapping directories and reloading from the new
+    /// slot. Throws when an invalid index is provided.
+    /// </summary>
+    /// <param name="slot">Index of the slot to activate.</param>
+    public void ChangeSlot(int slot)
+    {
+        if (slot < 0 || slot >= SaveSlotManager.MaxSlots)
+            throw new ArgumentOutOfRangeException(nameof(slot), "Invalid save slot index");
+
+        if (slot == SaveSlotManager.CurrentSlot)
+            return; // already using this slot
+
+        // Persist current state before redirecting file paths.
+        SaveDataToFile();
+        SaveSlotManager.SetSlot(slot);
+        savePath = SaveSlotManager.GetPath("savegame.json");
+        LoadData();
+    }
 }

--- a/Assets/Scripts/SaveSlotManager.cs
+++ b/Assets/Scripts/SaveSlotManager.cs
@@ -2,6 +2,14 @@ using System;
 using System.IO;
 using UnityEngine;
 
+// -----------------------------------------------------------------------------
+// SaveSlotManager
+// -----------------------------------------------------------------------------
+// Static helper used by SaveGameManager to determine where save files are
+// stored. Each slot corresponds to its own directory under the application's
+// persistent data path. The active slot index is persisted using PlayerPrefs so
+// profiles remain consistent across sessions.
+// -----------------------------------------------------------------------------
 /// <summary>
 /// Manages the currently selected save slot. Each slot stores game data in a
 /// separate folder under <see cref="Application.persistentDataPath"/> so multiple
@@ -42,7 +50,8 @@ public static class SaveSlotManager
 
     /// <summary>
     /// Returns a path inside the current slot's directory for the given file
-    /// name. The directory is created if it does not already exist.
+    /// name. The directory is created if it does not already exist. Callers are
+    /// expected to provide only a file name, not a full or relative path.
     /// </summary>
     public static string GetPath(string fileName)
     {

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -100,6 +100,25 @@ public class StageManager : MonoBehaviour
     [Tooltip("Ordered list of data for each stage.")]
     public StageDataSO[] stages;
 
+    // List of addressable handles currently loaded so they can be released
+    // when the stage changes. Helps prevent memory leaks from dangling assets.
+    private readonly System.Collections.Generic.List<AsyncOperationHandle> loadedHandles =
+        new System.Collections.Generic.List<AsyncOperationHandle>();
+
+    // Releases all loaded addressable assets and clears the handle list. Called
+    // before loading a new stage and when this component is destroyed.
+    private void ReleaseLoadedAssets()
+    {
+        foreach (var handle in loadedHandles)
+        {
+            if (handle.IsValid())
+            {
+                Addressables.Release(handle);
+            }
+        }
+        loadedHandles.Clear();
+    }
+
     void Awake()
     {
         // Subscribe to stage unlock notifications from the GameManager.
@@ -130,6 +149,7 @@ public class StageManager : MonoBehaviour
         {
             GameManager.Instance.OnStageUnlocked -= ApplyStage;
         }
+        ReleaseLoadedAssets();
     }
 
     /// <summary>
@@ -143,6 +163,8 @@ public class StageManager : MonoBehaviour
         {
             StopCoroutine(loadRoutine);
         }
+        // Release assets from the previous stage before loading new ones.
+        ReleaseLoadedAssets();
         loadRoutine = StartCoroutine(LoadStageRoutine(stageIndex));
     }
 
@@ -173,12 +195,12 @@ public class StageManager : MonoBehaviour
             data.backgroundSprite.RuntimeKeyIsValid())
         {
             AsyncOperationHandle<Sprite> bgHandle = data.backgroundSprite.LoadAssetAsync<Sprite>();
+            loadedHandles.Add(bgHandle);
             yield return bgHandle;
             if (bgHandle.Status == AsyncOperationStatus.Succeeded)
             {
                 bgSprite = bgHandle.Result;
             }
-            Addressables.Release(bgHandle);
         }
 
         if (parallaxBackground != null && bgSprite != null)
@@ -245,7 +267,8 @@ public class StageManager : MonoBehaviour
     }
 
     // Utility coroutine to load a set of GameObject references via Addressables
-    // and invoke a callback with the resulting array.
+    // and invoke a callback with the resulting array. Handles are tracked so
+    // assets can be released when the stage changes.
     private IEnumerator LoadPrefabs(AssetReferenceGameObject[] refs, System.Action<GameObject[]> setter)
     {
         if (refs == null || refs.Length == 0)
@@ -260,12 +283,12 @@ public class StageManager : MonoBehaviour
             if (r == null || !r.RuntimeKeyIsValid())
                 continue;
             AsyncOperationHandle<GameObject> handle = r.LoadAssetAsync();
+            loadedHandles.Add(handle);
             yield return handle;
             if (handle.Status == AsyncOperationStatus.Succeeded)
             {
                 list.Add(handle.Result);
             }
-            Addressables.Release(handle);
         }
         setter?.Invoke(list.ToArray());
     }

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -72,5 +72,27 @@ public class InputManagerTests
         Assert.IsNotNull(field.GetValue(null), "TriggerRumble should start a coroutine when a gamepad is present");
         InputSystem.RemoveDevice(gamepad);
     }
+
+    /// <summary>
+    /// Rumble should end even when Time.timeScale is zero. WaitForSecondsRealtime
+    /// ensures the coroutine finishes while the game is paused.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator TriggerRumble_StopsWhilePaused()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        InputManager.SetRumbleEnabled(true);
+
+        Time.timeScale = 0f;
+        InputManager.TriggerRumble(0.5f, 0.01f);
+
+        FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
+        while (field.GetValue(null) != null)
+            yield return null;
+
+        Assert.IsNull(field.GetValue(null), "Coroutine should complete even when paused");
+        Time.timeScale = 1f;
+        InputSystem.RemoveDevice(gamepad);
+    }
 }
 #endif

--- a/Assets/Tests/EditMode/PlayerControllerTests.cs
+++ b/Assets/Tests/EditMode/PlayerControllerTests.cs
@@ -182,6 +182,29 @@ public class PlayerControllerTests
         Object.DestroyImmediate(player);
     }
 
+    [Test]
+    public void EnhancedGravity_IgnoresZeroGravity()
+    {
+        // Physics2D.gravity.normalized returns NaN when gravity is zero. The
+        // method should early out to avoid corrupting the velocity vector.
+        var player = new GameObject("player");
+        var rb = player.AddComponent<Rigidbody2D>();
+        player.AddComponent<CapsuleCollider2D>();
+        var pc = player.AddComponent<PlayerController>();
+
+        rb.velocity = new Vector2(0f, 1f);
+        Physics2D.gravity = Vector2.zero;
+
+        typeof(PlayerController)
+            .GetMethod("ApplyEnhancedGravity", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pc, new object[] { 0.1f, false });
+
+        Assert.AreEqual(1f, rb.velocity.y, 0.001f, "Velocity should remain unchanged when gravity is zero");
+
+        Physics2D.gravity = new Vector2(0f, -9.81f);
+        Object.DestroyImmediate(player);
+    }
+
 #if ENABLE_INPUT_SYSTEM
     [Test]
     public void AttemptJump_TriggersRumble()

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -13,7 +13,15 @@ public class SaveGameManagerTests
     {
         // Ensure a clean file and PlayerPrefs state before each test
         PlayerPrefs.DeleteAll();
-        File.Delete(Path.Combine(Application.persistentDataPath, "savegame.json"));
+        for (int i = 0; i < SaveSlotManager.MaxSlots; i++)
+        {
+            string path = SaveSlotManager.GetPath("savegame.json").Replace($"slot_{SaveSlotManager.CurrentSlot}", $"slot_{i}");
+            if (File.Exists(path))
+                File.Delete(path);
+            string dir = Path.GetDirectoryName(path);
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, true);
+        }
     }
 
     [Test]
@@ -144,5 +152,26 @@ public class SaveGameManagerTests
         Assert.AreEqual(0, save.GetUpgradeLevel(UpgradeType.MagnetDuration));
 
         Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void ChangeSlot_SwitchesSavePath()
+    {
+        // Write data to the initial slot then change to a new slot and verify
+        // values persist separately.
+        SaveSlotManager.SetSlot(0);
+        var obj = new GameObject("save");
+        var mgr = obj.AddComponent<SaveGameManager>();
+        mgr.Coins = 2;
+        mgr.ChangeSlot(1);
+        mgr.Coins = 5;
+        Object.DestroyImmediate(obj);
+
+        var obj2 = new GameObject("save2");
+        var mgr2 = obj2.AddComponent<SaveGameManager>();
+        Assert.AreEqual(5, mgr2.Coins, "Slot 1 should contain updated value");
+        mgr2.ChangeSlot(0);
+        Assert.AreEqual(2, mgr2.Coins, "Slot 0 should retain original value");
+        Object.DestroyImmediate(obj2);
     }
 }

--- a/Assets/Tests/EditMode/StageManagerTests.cs
+++ b/Assets/Tests/EditMode/StageManagerTests.cs
@@ -167,6 +167,45 @@ public class StageManagerTests
         Object.DestroyImmediate(smObj);
     }
 
+    /// <summary>
+    /// Applying a new stage should release addressable handles from the
+    /// previous stage to prevent memory leaks.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator ApplyStage_ReleasesOldHandles()
+    {
+        var smObj = new GameObject("sm");
+        var sm = smObj.AddComponent<StageManager>();
+        sm.parallaxBackground = new GameObject("bg").AddComponent<ParallaxBackground>();
+        sm.obstacleSpawner = smObj.AddComponent<ObstacleSpawner>();
+        sm.hazardSpawner = smObj.AddComponent<HazardSpawner>();
+
+        var first = ScriptableObject.CreateInstance<StageDataSO>();
+        first.stage = new StageManager.StageData { backgroundSprite = new AssetReferenceSprite("00000000000000000000000000000003") };
+        var second = ScriptableObject.CreateInstance<StageDataSO>();
+        second.stage = new StageManager.StageData { backgroundSprite = new AssetReferenceSprite("00000000000000000000000000000004") };
+        sm.stages = new[] { first, second };
+
+        sm.ApplyStage(0);
+        FieldInfo routineField = typeof(StageManager).GetField("loadRoutine", BindingFlags.NonPublic | BindingFlags.Instance);
+        FieldInfo handlesField = typeof(StageManager).GetField("loadedHandles", BindingFlags.NonPublic | BindingFlags.Instance);
+        while (routineField.GetValue(sm) != null)
+            yield return null;
+        var handles = (System.Collections.Generic.List<AsyncOperationHandle>)handlesField.GetValue(sm);
+        AsyncOperationHandle oldHandle = handles.Count > 0 ? handles[0] : default;
+
+        sm.ApplyStage(1);
+        while (routineField.GetValue(sm) != null)
+            yield return null;
+        handles = (System.Collections.Generic.List<AsyncOperationHandle>)handlesField.GetValue(sm);
+        Assert.IsFalse(oldHandle.IsValid(), "Old handles should be released");
+        Assert.AreEqual(1, handles.Count, "Handle list should reflect only current stage");
+
+        Object.DestroyImmediate(smObj);
+        Object.DestroyImmediate(first);
+        Object.DestroyImmediate(second);
+    }
+
     [Test]
     public void Awake_RegistersSpawnersWithAdaptiveManager()
     {


### PR DESCRIPTION
## Summary
- ensure rumble works when the game is paused
- guard against zero gravity in `ApplyEnhancedGravity`
- allow runtime switching of save slots
- track and release stage assets when changing stages
- expand docs for `PlayerShield` and `SaveSlotManager`
- test rumble pause behaviour, gravity edge case, slot switching and asset handle release

## Testing
- `npm test`