### PR TITLE
Fix early exit logic and add persistence tests

### DIFF
--- a/Assets/Scripts/CoinMagnet.cs
+++ b/Assets/Scripts/CoinMagnet.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 /// Component placed on the player that can temporarily attract nearby
 /// coins. When activated, all coins inside <see cref="magnetRadius"/>
 /// will move toward the player for the given duration.
+/// 2026 update: Awake now validates the collider buffer size to avoid
+/// zero-length arrays when the value is misconfigured in the inspector.
 /// </summary>
 public class CoinMagnet : MonoBehaviour
 {
@@ -25,6 +27,7 @@ public class CoinMagnet : MonoBehaviour
     /// <summary>
     /// How many colliders can be detected each frame.
     /// </summary>
+    [Tooltip("Number of colliders checked each frame. Value must be at least 1.")]
     [SerializeField]
     private int colliderBufferSize = 10;
     // Preallocated buffer to store detected colliders.
@@ -38,6 +41,11 @@ public class CoinMagnet : MonoBehaviour
     /// </summary>
     void Awake()
     {
+        if (colliderBufferSize <= 0)
+        {
+            Debug.LogWarning("colliderBufferSize must be positive. Defaulting to 1.", this);
+            colliderBufferSize = 1;
+        }
         _colliderBuffer = new Collider2D[colliderBufferSize];
     }
 

--- a/Assets/Scripts/DailyChallengeManager.cs
+++ b/Assets/Scripts/DailyChallengeManager.cs
@@ -84,12 +84,14 @@ public class DailyChallengeManager : MonoBehaviour
                 if (GameManager.Instance != null)
                 {
                     state.progress = Mathf.FloorToInt(GameManager.Instance.GetDistance());
+                    SaveState();
                 }
                 break;
             case ChallengeType.Coins:
                 if (GameManager.Instance != null)
                 {
                     state.progress = GameManager.Instance.GetCoins();
+                    SaveState();
                 }
                 break;
         }
@@ -206,6 +208,23 @@ public class DailyChallengeManager : MonoBehaviour
         if (SteamManager.Instance != null)
         {
             SteamManager.Instance.UnlockAchievement(AchComplete);
+        }
+    }
+
+    // Persist the challenge whenever the application quits so progress is not
+    // lost on shutdown.
+    void OnApplicationQuit()
+    {
+        SaveState();
+    }
+
+    // Mobile platforms may pause the app without quitting. Save progress when
+    // entering the background.
+    void OnApplicationPause(bool paused)
+    {
+        if (paused)
+        {
+            SaveState();
         }
     }
 }

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -13,6 +13,8 @@ using System.Collections;
 /// can also be queried through <see cref="GetHorizontal"/>. If the package is not
 /// present the manager falls back to legacy <see cref="KeyCode"/> queries.
 /// Key bindings are saved to <see cref="PlayerPrefs"/>.
+/// 2026 fix: static constructor now reuses an existing RumbleHost object so
+/// domain reloads in the Unity editor do not accumulate hidden hosts.
 /// </summary>
 public static class InputManager
 {
@@ -106,12 +108,26 @@ public static class InputManager
         // Load rumble preference (enabled by default).
         RumbleEnabled = PlayerPrefs.GetInt(RumblePref, 1) == 1;
 #if ENABLE_INPUT_SYSTEM
-        // Create a hidden object for coroutine execution so rumble can
-        // run without requiring a separate manager component.
-        var hostObj = new GameObject("InputManagerRumbleHost");
-        hostObj.hideFlags = HideFlags.HideAndDontSave;
-        Object.DontDestroyOnLoad(hostObj);
-        rumbleHost = hostObj.AddComponent<RumbleHost>();
+        // Locate an existing host object when scripts reload in the editor so
+        // duplicates are not created during domain reloads.
+        var existing = GameObject.Find("InputManagerRumbleHost");
+        if (existing != null)
+        {
+            rumbleHost = existing.GetComponent<RumbleHost>();
+            if (rumbleHost == null)
+            {
+                rumbleHost = existing.AddComponent<RumbleHost>();
+            }
+        }
+        else
+        {
+            // Create a hidden object for coroutine execution so rumble can run
+            // without requiring a separate manager component.
+            var hostObj = new GameObject("InputManagerRumbleHost");
+            hostObj.hideFlags = HideFlags.HideAndDontSave;
+            Object.DontDestroyOnLoad(hostObj);
+            rumbleHost = hostObj.AddComponent<RumbleHost>();
+        }
         // Setup actions so either keyboard or various gamepads can trigger them.
         jumpAction = new InputAction("Jump", InputActionType.Button);
         jumpAction.AddBinding(PlayerPrefs.GetString(JumpBindingPref, "<Keyboard>/space"));
@@ -657,6 +673,14 @@ public static class InputManager
     }
 
     // Lightweight MonoBehaviour used solely to run coroutines for rumble.
-    private class RumbleHost : MonoBehaviour {}
+    private class RumbleHost : MonoBehaviour
+    {
+        // Destroy the host when the application quits so a fresh instance is
+        // created on the next domain reload instead of accumulating objects.
+        void OnApplicationQuit()
+        {
+            Destroy(gameObject);
+        }
+    }
 #endif
 }

--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -11,6 +11,8 @@
 // 2025 bug fix: loading no longer throws when the "upgrades" array is missing
 // from a legacy save file. The loader now checks for null before iterating so
 // older saves continue to load correctly.
+// 2026 update: SaveDataToFile now catches IO exceptions and cleans up temporary
+// files to prevent crashes when the disk is unwritable.
 // -----------------------------------------------------------------------------
 
 using System;
@@ -316,9 +318,27 @@ public class SaveGameManager : MonoBehaviour
         // Write to a temp file first, then replace the original. This guards
         // against partial writes leaving a corrupt save file.
         string tempPath = savePath + ".tmp";
-        File.WriteAllText(tempPath, json);
-        File.Copy(tempPath, savePath, true);
-        File.Delete(tempPath);
+        try
+        {
+            // Writing to a temporary file first reduces the chance of leaving a
+            // partially written save behind if the application closes or an
+            // exception occurs mid-write.
+            File.WriteAllText(tempPath, json);
+            File.Copy(tempPath, savePath, true);
+        }
+        catch (IOException ex)
+        {
+            Debug.LogWarning($"Failed to write save file: {ex.Message}");
+        }
+        finally
+        {
+            // Ensure any temp file is removed regardless of success so future
+            // attempts are not blocked.
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -9,6 +9,8 @@
 // asynchronously so stages can stream in without freezing the main thread.
 // Music tracks are also swapped using AudioManager's cross-fading functionality
 // when a new stage begins.
+// 2026 fix: LoadStageRoutine now clears its coroutine reference when exiting
+// early so callers don't hold on to a stale handle.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -175,14 +177,21 @@ public class StageManager : MonoBehaviour
     // spawners when complete.
     private IEnumerator LoadStageRoutine(int stageIndex)
     {
+        // Immediately exit and clear the coroutine reference when provided an
+        // invalid index or the stages array is missing. This prevents callers
+        // from retaining a stale coroutine handle after an early bailout.
         if (stages == null || stageIndex < 0 || stageIndex >= stages.Length)
         {
-            yield break; // invalid index or no data
+            loadRoutine = null;
+            UIManager.Instance?.HideLoadingIndicator();
+            yield break;
         }
 
         StageDataSO asset = stages[stageIndex];
         if (asset == null)
         {
+            loadRoutine = null;
+            UIManager.Instance?.HideLoadingIndicator();
             yield break; // asset missing
         }
         StageData data = asset.stage;

--- a/Assets/Tests/EditMode/CoinMagnetTests.cs
+++ b/Assets/Tests/EditMode/CoinMagnetTests.cs
@@ -46,4 +46,27 @@ public class CoinMagnetTests
 
         Object.DestroyImmediate(player);
     }
+
+    /// <summary>
+    /// Awake should clamp the collider buffer size to a minimum of one and log
+    /// a warning when configured with an invalid value.
+    /// </summary>
+    [Test]
+    public void Awake_InvalidBufferSize_ClampsAndLogs()
+    {
+        var player = new GameObject("player");
+        var magnet = player.AddComponent<CoinMagnet>();
+        var sizeField = typeof(CoinMagnet).GetField("colliderBufferSize", BindingFlags.NonPublic | BindingFlags.Instance);
+        sizeField.SetValue(magnet, 0);
+        var awake = typeof(CoinMagnet).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("colliderBufferSize"));
+        awake.Invoke(magnet, null);
+
+        var bufferField = typeof(CoinMagnet).GetField("_colliderBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
+        var buffer = (Collider2D[])bufferField.GetValue(magnet);
+        Assert.AreEqual(1, buffer.Length);
+
+        Object.DestroyImmediate(player);
+    }
 }

--- a/Assets/Tests/EditMode/DailyChallengeManagerTests.cs
+++ b/Assets/Tests/EditMode/DailyChallengeManagerTests.cs
@@ -154,4 +154,47 @@ public class DailyChallengeManagerTests
         public long expires;
         public bool completed;
     }
+
+    /// <summary>
+    /// Progress for distance and coin challenges should be persisted every
+    /// frame so exiting the game does not reset progress.
+    /// </summary>
+    [Test]
+    public void Update_SavesProgressForDistanceAndCoins()
+    {
+        var state = new PrivateChallengeState
+        {
+            type = DailyChallengeManager.ChallengeType.Distance,
+            target = 10,
+            progress = 0,
+            powerUp = DailyChallengeManager.PowerUpType.Magnet,
+            expires = System.DateTime.UtcNow.AddDays(1).Ticks,
+            completed = false
+        };
+        PlayerPrefs.SetString("DailyChallengeData", JsonUtility.ToJson(state));
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+        typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, 4f);
+
+        var dcObj = new GameObject("dc");
+        var dc = dcObj.AddComponent<DailyChallengeManager>();
+
+        dc.Update();
+        var loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
+        Assert.AreEqual(4, loaded.progress, "Distance progress should be saved");
+
+        loaded.type = DailyChallengeManager.ChallengeType.Coins;
+        loaded.progress = 0;
+        PlayerPrefs.SetString("DailyChallengeData", JsonUtility.ToJson(loaded));
+        typeof(GameManager).GetField("coins", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, 3);
+        dc.Update();
+
+        loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
+        Assert.AreEqual(3, loaded.progress, "Coin progress should be saved");
+
+        Object.DestroyImmediate(dcObj);
+        Object.DestroyImmediate(gmObj);
+    }
 }

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -1,6 +1,7 @@
 #if ENABLE_INPUT_SYSTEM
 using NUnit.Framework;
 using System.Reflection;
+using UnityEngine;
 using UnityEngine.InputSystem;
 
 /// <summary>
@@ -93,6 +94,35 @@ public class InputManagerTests
         Assert.IsNull(field.GetValue(null), "Coroutine should complete even when paused");
         Time.timeScale = 1f;
         InputSystem.RemoveDevice(gamepad);
+    }
+
+    /// <summary>
+    /// Reinitializing InputManager should not spawn multiple rumble hosts.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator StaticConstructor_ReusesRumbleHost()
+    {
+        InputManager.GetJumpDown();
+        yield return null;
+        int before = 0;
+        foreach (var go in Object.FindObjectsOfType<GameObject>())
+        {
+            if (go.name == "InputManagerRumbleHost")
+                before++;
+        }
+
+        typeof(InputManager).GetField("rumbleHost", BindingFlags.NonPublic | BindingFlags.Static).SetValue(null, null);
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(InputManager).TypeHandle);
+        yield return null;
+
+        int after = 0;
+        foreach (var go in Object.FindObjectsOfType<GameObject>())
+        {
+            if (go.name == "InputManagerRumbleHost")
+                after++;
+        }
+
+        Assert.AreEqual(before, after, "Only one rumble host should exist after reinit");
     }
 }
 #endif

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -1,6 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 /// <summary>
 /// Tests covering the JSON serialization and migration behaviour of
@@ -173,5 +176,26 @@ public class SaveGameManagerTests
         mgr2.ChangeSlot(0);
         Assert.AreEqual(2, mgr2.Coins, "Slot 0 should retain original value");
         Object.DestroyImmediate(obj2);
+    }
+
+    /// <summary>
+    /// Saving to an invalid path should log a warning rather than throwing an
+    /// exception so the game can continue running.
+    /// </summary>
+    [Test]
+    public void SaveDataToFile_InvalidPath_LogsWarning()
+    {
+        var obj = new GameObject("save");
+        var mgr = obj.AddComponent<SaveGameManager>();
+
+        FieldInfo pathField = typeof(SaveGameManager).GetField("savePath", BindingFlags.NonPublic | BindingFlags.Instance);
+        pathField.SetValue(mgr, Path.Combine(Application.dataPath, "no_such_dir", "save.json"));
+
+        LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("Failed to write save file"));
+
+        MethodInfo method = typeof(SaveGameManager).GetMethod("SaveDataToFile", BindingFlags.NonPublic | BindingFlags.Instance);
+        method.Invoke(mgr, null);
+
+        Object.DestroyImmediate(obj);
     }
 }

--- a/Assets/Tests/EditMode/StageManagerTests.cs
+++ b/Assets/Tests/EditMode/StageManagerTests.cs
@@ -239,5 +239,25 @@ public class StageManagerTests
         typeof(AdaptiveDifficultyManager).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)
             .SetValue(null, null);
     }
+
+    /// <summary>
+    /// When an invalid stage index is supplied the coroutine reference should
+    /// clear immediately so callers do not hold a stale handle.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator LoadStageRoutine_InvalidIndex_ClearsReference()
+    {
+        var smObj = new GameObject("sm");
+        var sm = smObj.AddComponent<StageManager>();
+        sm.stages = new StageDataSO[0];
+
+        sm.ApplyStage(5); // out of bounds
+
+        FieldInfo field = typeof(StageManager).GetField("loadRoutine", BindingFlags.NonPublic | BindingFlags.Instance);
+        yield return null; // allow coroutine to run
+        Assert.IsNull(field.GetValue(sm), "loadRoutine should be cleared after early exit");
+
+        Object.DestroyImmediate(smObj);
+    }
 }
 


### PR DESCRIPTION
## Summary
- clear coroutine reference on invalid stage index in `StageManager`
- guard save writes in `SaveGameManager` with try/catch
- persist daily challenge progress each update and on quit
- reuse rumble host across domain reloads
- validate collider buffer size for `CoinMagnet`
- add extensive unit tests for the new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c9532d54c8321b8ab1bd05bd8b08f