### PR TITLE
Fix gravity reset and batch upgrade saves

### DIFF
--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -201,6 +201,26 @@ public class SaveGameManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Updates multiple upgrade levels in a single operation. The provided
+    /// dictionary may contain any subset of <see cref="UpgradeType"/> values.
+    /// A single file write occurs after all levels are updated.
+    /// </summary>
+    /// <param name="levels">Mapping of upgrade types to their desired levels.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="levels"/> is null.</exception>
+    public void UpdateUpgradeLevels(Dictionary<UpgradeType, int> levels)
+    {
+        if (levels == null)
+            throw new ArgumentNullException(nameof(levels));
+
+        foreach (var kvp in levels)
+        {
+            upgradeLevels[kvp.Key] = Mathf.Max(0, kvp.Value);
+        }
+
+        SaveDataToFile();
+    }
+
+    /// <summary>
     /// Reads existing save data from disk or migrates old PlayerPrefs data when
     /// the save file does not yet exist.
     /// </summary>
@@ -298,7 +318,12 @@ public class SaveGameManager : MonoBehaviour
     /// file is used so the existing save is not corrupted if the application
     /// closes mid-write.
     /// </summary>
-    private void SaveDataToFile()
+    /// <summary>
+    /// Writes the current <see cref="SaveData"/> instance to disk. Marked as
+    /// protected so tests can override the method and record how many times a
+    /// save occurs without duplicating the serialization logic.
+    /// </summary>
+    protected virtual void SaveDataToFile()
     {
         data.version = CurrentVersion;
         data.musicVolume = Mathf.Clamp01(data.musicVolume);

--- a/Assets/Scripts/ShopManager.cs
+++ b/Assets/Scripts/ShopManager.cs
@@ -138,9 +138,10 @@ public class ShopManager : MonoBehaviour
         if (save == null) return;
 
         save.Coins = Coins;
-        foreach (var kvp in upgradeLevels)
-        {
-            save.SetUpgradeLevel(kvp.Key, kvp.Value);
-        }
+
+        // Batch update all upgrade levels to minimise file writes. The
+        // individual setter triggers a disk write each call which scales
+        // poorly with many upgrades.
+        save.UpdateUpgradeLevels(new Dictionary<UpgradeType, int>(upgradeLevels));
     }
 }

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -107,6 +107,12 @@ public class StageManager : MonoBehaviour
     private readonly System.Collections.Generic.List<AsyncOperationHandle> loadedHandles =
         new System.Collections.Generic.List<AsyncOperationHandle>();
 
+    // Stores the gravity value present when this component awakens so it can be
+    // restored if the object is destroyed. Stage data may scale gravity for
+    // variety and forgetting to revert it would affect other scenes and the
+    // editor.
+    private Vector2 defaultGravity;
+
     // Releases all loaded addressable assets and clears the handle list. Called
     // before loading a new stage and when this component is destroyed.
     private void ReleaseLoadedAssets()
@@ -123,6 +129,11 @@ public class StageManager : MonoBehaviour
 
     void Awake()
     {
+        // Record the starting gravity so it can be restored when this manager
+        // is destroyed. Stage modifiers may adjust gravity and leaving the
+        // scaled value active would affect future scenes and the editor.
+        defaultGravity = Physics2D.gravity;
+
         // Subscribe to stage unlock notifications from the GameManager.
         if (GameManager.Instance != null)
         {
@@ -152,6 +163,10 @@ public class StageManager : MonoBehaviour
             GameManager.Instance.OnStageUnlocked -= ApplyStage;
         }
         ReleaseLoadedAssets();
+
+        // Restore the default gravity so other scenes are not affected by the
+        // stage's custom value.
+        Physics2D.gravity = defaultGravity;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -198,4 +198,38 @@ public class SaveGameManagerTests
 
         Object.DestroyImmediate(obj);
     }
+
+    // Spy subclass used to count save operations
+    private class SaveGameManagerSpy : SaveGameManager
+    {
+        public int Calls { get; private set; }
+        protected override void SaveDataToFile()
+        {
+            Calls++;
+            base.SaveDataToFile();
+        }
+    }
+
+    /// <summary>
+    /// Updating multiple upgrade levels should result in a single save to disk
+    /// regardless of how many entries are modified.
+    /// </summary>
+    [Test]
+    public void UpdateUpgradeLevels_BatchesWrites()
+    {
+        var obj = new GameObject("save");
+        var mgr = obj.AddComponent<SaveGameManagerSpy>();
+
+        var dict = new Dictionary<UpgradeType, int>
+        {
+            { UpgradeType.MagnetDuration, 1 },
+            { UpgradeType.SpeedBoostDuration, 2 }
+        };
+
+        mgr.UpdateUpgradeLevels(dict);
+
+        Assert.AreEqual(1, mgr.Calls);
+
+        Object.DestroyImmediate(obj);
+    }
 }

--- a/Assets/Tests/EditMode/ShopManagerTests.cs
+++ b/Assets/Tests/EditMode/ShopManagerTests.cs
@@ -8,6 +8,17 @@ using System.Collections.Generic;
 /// </summary>
 public class ShopManagerTests
 {
+    // Local spy used to verify the number of times SaveGameManager writes data
+    // during SaveState calls.
+    private class SaveGameManagerSpy : SaveGameManager
+    {
+        public int Calls { get; private set; }
+        protected override void SaveDataToFile()
+        {
+            Calls++;
+            base.SaveDataToFile();
+        }
+    }
     [Test]
     public void AddCoins_PersistsTotal()
     {
@@ -206,6 +217,45 @@ public class ShopManagerTests
         Object.DestroyImmediate(powerObj);
         Object.DestroyImmediate(player);
         Object.DestroyImmediate(shopObj);
+        Object.DestroyImmediate(saveObj);
+    }
+
+    /// <summary>
+    /// Saving multiple upgrades should result in only a single disk write from
+    /// <see cref="SaveGameManager.UpdateUpgradeLevels"/> instead of one per
+    /// upgrade entry.
+    /// </summary>
+    [Test]
+    public void SaveState_BatchesUpgradeWrites()
+    {
+        System.IO.File.Delete(System.IO.Path.Combine(
+            Application.persistentDataPath, "savegame.json"));
+
+        var saveObj = new GameObject("save");
+        var save = saveObj.AddComponent<SaveGameManagerSpy>();
+
+        var go = new GameObject("shop");
+        var sm = go.AddComponent<ShopManager>();
+        sm.availableUpgrades = new[]
+        {
+            new ShopManager.UpgradeData { type = UpgradeType.MagnetDuration, cost = 1, effect = 0 },
+            new ShopManager.UpgradeData { type = UpgradeType.SpeedBoostDuration, cost = 1, effect = 0 }
+        };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(sm, null);
+
+        // Simulate purchase by directly modifying the upgrade dictionary
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (Dictionary<UpgradeType, int>)dictField.GetValue(sm);
+        levels[UpgradeType.MagnetDuration] = 1;
+        levels[UpgradeType.SpeedBoostDuration] = 2;
+
+        typeof(ShopManager).GetMethod("SaveState", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(sm, null);
+
+        Assert.AreEqual(2, save.Calls); // one for coins, one for upgrades
+
+        Object.DestroyImmediate(go);
         Object.DestroyImmediate(saveObj);
     }
 }

--- a/Assets/Tests/EditMode/StageManagerTests.cs
+++ b/Assets/Tests/EditMode/StageManagerTests.cs
@@ -259,5 +259,41 @@ public class StageManagerTests
 
         Object.DestroyImmediate(smObj);
     }
+
+    /// <summary>
+    /// Destroying the manager should reset any gravity modifications so later
+    /// scenes start with the default physics settings.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator OnDestroy_RestoresGravity()
+    {
+        // Record the engine's default gravity prior to creating the manager.
+        Vector2 startGravity = Physics2D.gravity;
+
+        var smObj = new GameObject("sm");
+        var sm = smObj.AddComponent<StageManager>();
+        sm.parallaxBackground = new GameObject("bg").AddComponent<ParallaxBackground>();
+        sm.obstacleSpawner = smObj.AddComponent<ObstacleSpawner>();
+        sm.hazardSpawner = smObj.AddComponent<HazardSpawner>();
+
+        var stage = ScriptableObject.CreateInstance<StageDataSO>();
+        stage.stage = new StageManager.StageData
+        {
+            backgroundSprite = new AssetReferenceSprite("00000000000000000000000000000005"),
+            groundObstacles = new AssetReferenceGameObject[0],
+            gravityScale = 0.5f
+        };
+        sm.stages = new[] { stage };
+
+        sm.ApplyStage(0);
+        FieldInfo routineField = typeof(StageManager).GetField("loadRoutine", BindingFlags.NonPublic | BindingFlags.Instance);
+        while (routineField.GetValue(sm) != null)
+            yield return null;
+
+        Object.DestroyImmediate(smObj);
+        Assert.AreEqual(startGravity.y, Physics2D.gravity.y, 0.001f);
+
+        Object.DestroyImmediate(stage);
+    }
 }
 


### PR DESCRIPTION
## Summary
- restore global gravity when StageManager is destroyed
- batch upgrade writes through SaveGameManager.UpdateUpgradeLevels
- call new batch method from ShopManager
- test gravity restoration and save batching behaviour

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68786ec07a5c8321ab1fe5c474f44b02