### PR TITLE
Ensure EnemyBehavior uses world-space movement

### DIFF
--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -1,22 +1,35 @@
+// EnemyBehavior.cs
+// -----------------------------------------------------------------------------
+// AI controller for simple flying enemies that pursue the player horizontally.
+// Movement now uses world coordinates so rotation does not influence the
+// direction of travel, preventing erratic paths for rotated enemies.
+// -----------------------------------------------------------------------------
 using UnityEngine;
 
 /// <summary>
-/// Simple enemy AI that chases the player while the game is running.
-/// Used for flying bats or other mobile hazards spawned by
+/// Simple enemy AI that chases the player while the game is running. Designed
+/// for flying bats or other mobile hazards spawned by
 /// <see cref="HazardSpawner"/>.
 /// </summary>
 public class EnemyBehavior : MonoBehaviour
 {
+    // Movement speed in world units per second.
     public float speed = 3f;
 
+    // Cached reference to the player transform for efficient lookups.
     private Transform player;
 
     /// <summary>
-    /// Locates the player object so the enemy can chase it.
+    /// Locates the player object so the enemy can chase it. If no player is
+    /// found, the enemy remains idle. Assumes a GameObject tagged "Player"
+    /// exists in the scene.
     /// </summary>
     void Start()
     {
         GameObject obj = GameObject.FindGameObjectWithTag("Player");
+
+        // If the player is not found the enemy cannot move; leaving player null
+        // gracefully halts Update movement logic.
         if (obj != null)
         {
             player = obj.transform;
@@ -24,14 +37,26 @@ public class EnemyBehavior : MonoBehaviour
     }
 
     /// <summary>
-    /// Moves toward the player each frame while the game is running.
+    /// Moves toward the player each frame while the game is running. Movement
+    /// occurs in world space so the enemy's rotation does not alter the chase
+    /// direction, keeping pursuit behavior consistent.
     /// </summary>
     void Update()
     {
-        if (player == null) return;
-        if (GameManager.Instance == null || !GameManager.Instance.IsRunning()) return;
+        // Abort if no player has been located or the game is currently paused
+        // or stopped.
+        if (player == null)
+        {
+            return;
+        }
+        if (GameManager.Instance == null || !GameManager.Instance.IsRunning())
+        {
+            return;
+        }
 
+        // Calculate the normalized direction vector toward the player and move
+        // the enemy using world coordinates to remain independent of rotation.
         Vector3 dir = (player.position - transform.position).normalized;
-        transform.Translate(dir * speed * Time.deltaTime);
+        transform.Translate(dir * speed * Time.deltaTime, Space.World);
     }
 }

--- a/Assets/Tests/EditMode/EnemyBehaviorTests.cs
+++ b/Assets/Tests/EditMode/EnemyBehaviorTests.cs
@@ -1,0 +1,53 @@
+// EnemyBehaviorTests.cs
+// -----------------------------------------------------------------------------
+// Validates that EnemyBehavior moves enemies toward the player using world
+// coordinates, ensuring rotation does not alter the pursuit path.
+// -----------------------------------------------------------------------------
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+/// <summary>
+/// Test suite verifying the rotation-independent movement of EnemyBehavior.
+/// </summary>
+public class EnemyBehaviorTests
+{
+    /// <summary>
+    /// Ensures that two enemies, one rotated and one not, move identically
+    /// toward the player, demonstrating that movement calculations occur in
+    /// world space.
+    /// </summary>
+    [Test]
+    public void Update_MovementIndependentOfRotation()
+    {
+        // Create a player target positioned to the right of the origin.
+        var player = new GameObject("player");
+        player.transform.position = new Vector3(5f, 0f, 0f);
+
+        // Create two enemies at the origin, rotating one by 90 degrees.
+        var enemyA = new GameObject("enemyA");
+        var behaviorA = enemyA.AddComponent<EnemyBehavior>();
+        var enemyB = new GameObject("enemyB");
+        enemyB.transform.rotation = Quaternion.Euler(0f, 0f, 90f);
+        var behaviorB = enemyB.AddComponent<EnemyBehavior>();
+
+        // Manually assign the private player field via reflection so Update can
+        // execute without invoking Start().
+        var field = typeof(EnemyBehavior).GetField("player", BindingFlags.NonPublic | BindingFlags.Instance);
+        field.SetValue(behaviorA, player.transform);
+        field.SetValue(behaviorB, player.transform);
+
+        // Invoke Update on both behaviors to move them toward the player.
+        behaviorA.Update();
+        behaviorB.Update();
+
+        // Both enemies should occupy the same world position despite the
+        // rotation applied to enemyB, proving movement uses world coordinates.
+        Assert.AreEqual(enemyA.transform.position, enemyB.transform.position);
+
+        // Clean up all dynamically created objects to avoid polluting other tests.
+        Object.DestroyImmediate(enemyA);
+        Object.DestroyImmediate(enemyB);
+        Object.DestroyImmediate(player);
+    }
+}


### PR DESCRIPTION
## Summary
- use world-space translation in EnemyBehavior so rotation doesn't skew pursuit
- expand EnemyBehavior documentation and comments
- add unit test confirming rotation-independent movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eadc28fa4832189b10d84c91ad6f0