### PR TITLE
Add null-safe obstacle loading

### DIFF
--- a/Assets/Scripts/ObstacleSpawner.cs
+++ b/Assets/Scripts/ObstacleSpawner.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 /// probability weights and a spawn rate multiplier supplied by
 /// <see cref="StageManager"/>.
 /// </summary>
+/// <remarks>
+/// Updated to include explicit null checks before inspecting obstacle arrays
+/// in <see cref="Start"/>. This prevents <see cref="System.NullReferenceException"/>
+/// when obstacle collections are left unassigned in the Unity inspector or
+/// reset at runtime.
+/// </remarks>
 public class ObstacleSpawner : MonoBehaviour
 {
     public GameObject[] groundObstacles;
@@ -50,19 +56,32 @@ public class ObstacleSpawner : MonoBehaviour
     /// </summary>
     void Start()
     {
-        if (groundObstacles.Length == 0 && groundObstacleNames != null && groundObstacleNames.Length > 0)
+        // Load ground obstacle prefabs only when the array is null or empty
+        // and valid prefab names are provided. This defensive check prevents
+        // null reference errors when obstacles are not assigned in the
+        // inspector.
+        if ((groundObstacles == null || groundObstacles.Length == 0) &&
+            groundObstacleNames != null && groundObstacleNames.Length > 0)
         {
             groundObstacles = LoadPrefabs(groundObstacleNames);
         }
-        if (ceilingObstacles.Length == 0 && ceilingObstacleNames != null && ceilingObstacleNames.Length > 0)
+        // Repeat the same null-safe loading logic for ceiling obstacles.
+        if ((ceilingObstacles == null || ceilingObstacles.Length == 0) &&
+            ceilingObstacleNames != null && ceilingObstacleNames.Length > 0)
         {
             ceilingObstacles = LoadPrefabs(ceilingObstacleNames);
         }
-        if (movingPlatforms.Length == 0 && movingPlatformNames != null && movingPlatformNames.Length > 0)
+        // Apply null checks for moving platforms to avoid accessing an
+        // uninitialized array.
+        if ((movingPlatforms == null || movingPlatforms.Length == 0) &&
+            movingPlatformNames != null && movingPlatformNames.Length > 0)
         {
             movingPlatforms = LoadPrefabs(movingPlatformNames);
         }
-        if (rotatingHazards.Length == 0 && rotatingHazardNames != null && rotatingHazardNames.Length > 0)
+        // Ensure rotating hazards are loaded safely by verifying the array is
+        // not null before evaluating its length.
+        if ((rotatingHazards == null || rotatingHazards.Length == 0) &&
+            rotatingHazardNames != null && rotatingHazardNames.Length > 0)
         {
             rotatingHazards = LoadPrefabs(rotatingHazardNames);
         }

--- a/Assets/Tests/EditMode/ObstacleSpawnerTests.cs
+++ b/Assets/Tests/EditMode/ObstacleSpawnerTests.cs
@@ -5,8 +5,9 @@ using System.Collections.Generic;
 
 /// <summary>
 /// Tests for <see cref="ObstacleSpawner"/> confirming that spawn
-/// rates respond to stage multipliers and that pooled objects are
-/// reused rather than instantiated each time.
+/// rates respond to stage multipliers, pooled objects are reused rather
+/// than instantiated each time, and null obstacle arrays are handled
+/// safely during initialization.
 /// </summary>
 public class ObstacleSpawnerTests
 {
@@ -83,5 +84,40 @@ public class ObstacleSpawnerTests
         Object.DestroyImmediate(prefab);
         Object.DestroyImmediate(spawnerObj);
         Object.DestroyImmediate(gmObj);
+    }
+
+    [Test]
+    public void Start_LoadsPrefabsOnlyWhenArraysNull()
+    {
+        // This test verifies that Start performs null checks before accessing
+        // obstacle arrays, preventing runtime errors when the arrays are
+        // uninitialized and only name lists are provided.
+
+        var spawnerObj = new GameObject("spawner");
+        var spawner = spawnerObj.AddComponent<ObstacleSpawner>();
+
+        // Arrays remain null while names are supplied to trigger the loading
+        // logic. LoadPrefabs will return empty arrays because the names do not
+        // exist in the test environment, which is sufficient for verifying
+        // the null-safe conditional logic.
+        spawner.groundObstacleNames = new[] { "nonexistent" };
+        spawner.ceilingObstacleNames = new[] { "nonexistent" };
+        spawner.movingPlatformNames = new[] { "nonexistent" };
+        spawner.rotatingHazardNames = new[] { "nonexistent" };
+
+        // Invoke Start via reflection and ensure it does not throw.
+        Assert.DoesNotThrow(() =>
+            typeof(ObstacleSpawner).GetMethod("Start", BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(spawner, null),
+            "Start should handle null obstacle arrays without raising exceptions");
+
+        // After Start runs the obstacle arrays should be instantiated (even if
+        // empty) because names were provided.
+        Assert.IsNotNull(spawner.groundObstacles, "Ground obstacles array should be initialized");
+        Assert.IsNotNull(spawner.ceilingObstacles, "Ceiling obstacles array should be initialized");
+        Assert.IsNotNull(spawner.movingPlatforms, "Moving platforms array should be initialized");
+        Assert.IsNotNull(spawner.rotatingHazards, "Rotating hazards array should be initialized");
+
+        Object.DestroyImmediate(spawnerObj);
     }
 }


### PR DESCRIPTION
## Summary
- add defensive null checks before loading obstacle prefabs
- document null-handling behavior in ObstacleSpawner
- cover null array initialization with unit test

## Testing
- `npm test`