### PR TITLE
Preserve horizontal gravity during stage transitions

### DIFF
--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -11,6 +11,8 @@
 // when a new stage begins.
 // 2026 fix: LoadStageRoutine now clears its coroutine reference when exiting
 // early so callers don't hold on to a stale handle.
+// 2027 fix: Stage gravity scaling now preserves the existing horizontal
+// component so levels can apply sideways forces without them being reset.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -272,7 +274,11 @@ public class StageManager : MonoBehaviour
         {
             GameManager.Instance.SetStageSpeedMultiplier(data.speedMultiplier);
         }
-        Physics2D.gravity = new Vector2(0f, -9.81f * data.gravityScale);
+        // Preserve the existing horizontal gravity component while scaling only
+        // the vertical axis according to the stage's modifier. Some projects
+        // may use a non-zero X gravity for unique mechanics (e.g., sideways
+        // wind) and wiping it out here would cause subtle physics bugs.
+        Physics2D.gravity = new Vector2(defaultGravity.x, defaultGravity.y * data.gravityScale);
 
         // Choose a random music track for this stage and start a cross-fade
         if (data.stageMusic != null && data.stageMusic.Length > 0 && AudioManager.Instance != null)

--- a/Assets/Tests/EditMode/StageManagerTests.cs
+++ b/Assets/Tests/EditMode/StageManagerTests.cs
@@ -295,5 +295,52 @@ public class StageManagerTests
 
         Object.DestroyImmediate(stage);
     }
+
+    /// <summary>
+    /// Applying a stage should scale only the vertical component of gravity
+    /// while leaving the horizontal component untouched. Games may set a
+    /// sideways force (e.g., wind) using Physics2D.gravity.x; losing that value
+    /// when stages modify gravity would lead to inconsistent gameplay.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator ApplyStage_PreservesHorizontalGravity()
+    {
+        // Capture the engine's original gravity so it can be restored after the
+        // test to avoid contaminating other tests.
+        Vector2 originalGravity = Physics2D.gravity;
+
+        // Introduce a horizontal gravity component to verify it persists after
+        // stage application. The Y value is left at the engine default.
+        Physics2D.gravity = new Vector2(1f, originalGravity.y);
+
+        // Create a minimal StageManager with a single stage that doubles the
+        // gravity scale. No spawners or backgrounds are required for this check.
+        var stageManagerObject = new GameObject("stageManager");
+        var stageManager = stageManagerObject.AddComponent<StageManager>();
+        var stageAsset = ScriptableObject.CreateInstance<StageDataSO>();
+        stageAsset.stage = new StageManager.StageData { gravityScale = 2f };
+        stageManager.stages = new[] { stageAsset };
+
+        stageManager.ApplyStage(0);
+
+        // Wait for the asynchronous stage load to complete so gravity updates
+        // can be evaluated.
+        FieldInfo routineField = typeof(StageManager).GetField("loadRoutine", BindingFlags.NonPublic | BindingFlags.Instance);
+        while (routineField.GetValue(stageManager) != null)
+        {
+            yield return null;
+        }
+
+        // Only the vertical component should change; horizontal gravity must
+        // remain exactly as configured prior to applying the stage.
+        Assert.AreEqual(1f, Physics2D.gravity.x);
+        Assert.AreEqual(originalGravity.y * 2f, Physics2D.gravity.y, 0.001f);
+
+        // Cleanup objects and restore original gravity so subsequent tests run
+        // with the expected physics environment.
+        Object.DestroyImmediate(stageManagerObject);
+        Object.DestroyImmediate(stageAsset);
+        Physics2D.gravity = originalGravity;
+    }
 }
 


### PR DESCRIPTION
## Summary
- keep existing horizontal gravity when scaling stage gravity
- add EditMode test ensuring horizontal gravity is unaffected

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eba50f9e483218d7f045eefec113d