### PR TITLE
fix: guard duplicate GameManager initialization

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -39,6 +39,13 @@ using System.Collections;
 /// must provide positive durations and multipliers, preventing unintended
 /// slowdowns or permanent boosts from invalid arguments.
 /// </remarks>
+/// <remarks>
+/// 2028 fix: duplicates detected in <see cref="Awake"/> now return immediately
+/// after calling <c>Destroy</c>. Skipping the remainder of initialization avoids
+/// running setup on an object that is about to be destroyed, which previously
+/// led to occasional null reference errors when supporting singletons were
+/// missing.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -161,10 +168,15 @@ public class GameManager : MonoBehaviour
     /// </summary>
     void Awake()
     {
+        // Enforce the singleton pattern so only one manager controls the game
+        // state. The first instance persists across scenes while subsequent
+        // instances self-destruct.
         if (Instance == null)
         {
             Instance = this;
-            DontDestroyOnLoad(gameObject);
+            DontDestroyOnLoad(gameObject); // keep this manager alive between scenes
+
+            // Ensure required helper singletons exist before gameplay begins.
             if (AnalyticsManager.Instance == null)
             {
                 new GameObject("AnalyticsManager").AddComponent<AnalyticsManager>();
@@ -176,8 +188,15 @@ public class GameManager : MonoBehaviour
         }
         else
         {
+            // A GameManager already exists. Destroy this duplicate and exit
+            // immediately so the remaining initialization does not run on a
+            // soon-to-be destroyed object. Without this early return, later
+            // code could access missing dependencies and trigger
+            // NullReferenceException errors.
             Destroy(gameObject);
+            return;
         }
+
         // Load the persisted hardcore mode preference after ensuring
         // SaveGameManager exists. Default to false when no save is present.
         hardcoreMode = SaveGameManager.Instance != null && SaveGameManager.Instance.HardcoreMode;

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -282,4 +282,39 @@ public class GameManagerTests
         Object.DestroyImmediate(gmObj2);
         Object.DestroyImmediate(saveObj2);
     }
+
+    /// <summary>
+    /// Verifies that a duplicate <see cref="GameManager"/> exits early after
+    /// destroying itself and therefore does not recreate missing singleton
+    /// dependencies. This prevents null reference errors that would occur if
+    /// initialization continued on the destroyed instance.
+    /// </summary>
+    [Test]
+    public void Awake_DuplicateDoesNotReinitializeDependencies()
+    {
+        // Establish the primary manager which also spawns a SaveGameManager.
+        var primaryObj = new GameObject("gmPrimary");
+        primaryObj.AddComponent<GameManager>();
+
+        // Simulate the supporting SaveGameManager being missing by destroying
+        // it and clearing the static Instance field via reflection.
+        if (SaveGameManager.Instance != null)
+        {
+            Object.DestroyImmediate(SaveGameManager.Instance.gameObject);
+            var instField = typeof(SaveGameManager).GetField("<Instance>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic);
+            instField.SetValue(null, null);
+        }
+
+        // Create a second manager which should destroy itself and return
+        // before recreating the SaveGameManager dependency.
+        var duplicateObj = new GameObject("gmDuplicate");
+        duplicateObj.AddComponent<GameManager>();
+
+        // The dependency should remain absent, proving the duplicate aborted
+        // initialization after self-destruction.
+        Assert.IsNull(SaveGameManager.Instance);
+
+        Object.DestroyImmediate(primaryObj);
+        Object.DestroyImmediate(duplicateObj);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid null references by returning after destroying duplicate GameManager instances
- document singleton and duplicate handling in GameManager
- test that duplicate GameManager does not reinitialize dependencies

## Testing
- `npm test`
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*