### PR TITLE
feat: guard StartGame against missing player

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -56,6 +56,12 @@ using System.Collections;
 /// 2036 update: introduces <see cref="maxComboMultiplier"/> to cap coin combo
 /// rewards and align UI plus achievement logic with the new limit.
 /// </remarks>
+/// <remarks>
+/// 2038 update: <see cref="StartGame"/> now caches the player GameObject and
+/// verifies it exists before spawning starting power-ups. This validation avoids
+/// costly repeated <c>FindGameObjectWithTag</c> calls and prevents spawns when the
+/// player is missing, eliminating potential null reference errors.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -81,6 +87,8 @@ public class GameManager : MonoBehaviour
     private bool gravityFlipped;              // true while gravity is inverted
     private float coinComboTimer;             // countdown for maintaining a coin combo
     private int coinComboMultiplier = 1;      // current coin multiplier from the combo
+
+    private GameObject playerObject;          // cached reference to the player GameObject
 
     // Coin bonus power-up variables
     private float coinBonusTimer;             // remaining time coins are multiplied
@@ -445,6 +453,10 @@ public class GameManager : MonoBehaviour
     /// <summary>
     /// Resets all runtime variables and begins a new run.
     /// </summary>
+    /// <remarks>
+    /// 2038 update: verifies the player exists before spawning starting
+    /// power-ups and caches the reference to avoid redundant searches.
+    /// </remarks>
     public void StartGame()
     {
         // Always restore gravity before a new run in case the previous game
@@ -487,12 +499,26 @@ public class GameManager : MonoBehaviour
         }
         if (startingCount > 0 && startingPowerUps != null && startingPowerUps.Length > 0)
         {
-            GameObject player = GameObject.FindGameObjectWithTag("Player");
-            Vector3 pos = player != null ? player.transform.position : Vector3.zero;
-            for (int i = 0; i < startingCount; i++)
+            // Cache the player reference on first use to avoid repeated lookups.
+            if (playerObject == null)
             {
-                GameObject prefab = startingPowerUps[UnityEngine.Random.Range(0, startingPowerUps.Length)];
-                Instantiate(prefab, pos + Vector3.right * (i + 1), Quaternion.identity);
+                playerObject = GameObject.FindGameObjectWithTag("Player");
+            }
+
+            if (playerObject == null)
+            {
+                // Without a player we cannot determine a spawn position for the power-ups.
+                // Log a warning so designers know the upgrade could not be applied.
+                Debug.LogWarning("StartGame: Player object not found. Skipping starting power-up spawn.");
+            }
+            else
+            {
+                Vector3 spawnPosition = playerObject.transform.position;
+                for (int i = 0; i < startingCount; i++)
+                {
+                    GameObject prefab = startingPowerUps[UnityEngine.Random.Range(0, startingPowerUps.Length)];
+                    Instantiate(prefab, spawnPosition + Vector3.right * (i + 1), Quaternion.identity);
+                }
             }
         }
 

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -1,7 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 using System;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 /// <summary>
 /// Tests for core GameManager functionality such as coin counting and
@@ -316,5 +318,52 @@ public class GameManagerTests
 
         Object.DestroyImmediate(primaryObj);
         Object.DestroyImmediate(duplicateObj);
+    }
+
+    /// <summary>
+    /// Ensures <see cref="GameManager.StartGame"/> warns and skips spawning
+    /// starting power-ups when no player object exists in the scene.
+    /// </summary>
+    [Test]
+    public void StartGame_PlayerMissing_SkipsPowerUpSpawn()
+    {
+        // Create required singletons so upgrade data can be queried.
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+        var shopObj = new GameObject("shop");
+        var shop = shopObj.AddComponent<ShopManager>();
+        shop.availableUpgrades = new[]
+        {
+            new ShopManager.UpgradeData
+            {
+                type = UpgradeType.StartingPowerUp,
+                cost = 1,
+                effect = 1f
+            }
+        };
+        // Populate upgrade levels so the starting power-up count is one.
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(shop, null);
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (System.Collections.Generic.Dictionary<UpgradeType, int>)dictField.GetValue(shop);
+        levels[UpgradeType.StartingPowerUp] = 1;
+        dictField.SetValue(shop, levels);
+
+        // GameManager with a simple power-up prefab to instantiate.
+        var go = new GameObject("gm");
+        var gm = go.AddComponent<GameManager>();
+        gm.startingPowerUps = new[] { new GameObject("PowerUp") };
+
+        // Expect a warning about the missing player.
+        LogAssert.Expect(LogType.Warning, new Regex("Player object not found"));
+
+        gm.StartGame();
+
+        // The prefab should not have spawned because the player was absent.
+        Assert.IsNull(GameObject.Find("PowerUp(Clone)"));
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(shopObj);
+        Object.DestroyImmediate(saveObj);
     }
 }


### PR DESCRIPTION
## Summary
- cache player object and log a warning if missing before spawning starting power-ups
- add regression test covering missing player scenario during StartGame

## Testing
- `npm test`