### PR TITLE
Ensure PlayerController requires essential components

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,3 +1,10 @@
+// PlayerController.cs
+// --------------------
+// Manages all aspects of player movement and state within the game.
+// 2028 update: Added RequireComponent attribute to guarantee Rigidbody2D,
+// CapsuleCollider2D, and Animator components are present. This prevents null
+// reference errors when the script is placed on new prefabs.
+
 using UnityEngine;
 
 /// <summary>
@@ -20,6 +27,7 @@ using UnityEngine;
 // correctly if game modes invert gravity.
 // 2026 fix: Air-dive logic now guards against zero gravity to prevent
 // undefined velocity when Physics2D.gravity is a zero vector.
+[RequireComponent(typeof(Rigidbody2D), typeof(CapsuleCollider2D), typeof(Animator))]
 public class PlayerController : MonoBehaviour
 {
     // Force applied when jumping.

--- a/Assets/Tests/EditMode/PlayerControllerTests.cs
+++ b/Assets/Tests/EditMode/PlayerControllerTests.cs
@@ -1,3 +1,10 @@
+// PlayerControllerTests.cs
+// -----------------------
+// Contains EditMode unit tests validating the behaviour of PlayerController.
+// 2028 update: Adds verification that RequireComponent automatically appends
+// Rigidbody2D, CapsuleCollider2D, and Animator when the controller is added to
+// a GameObject lacking those dependencies.
+
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
@@ -16,6 +23,25 @@ using UnityEngine.InputSystem;
 /// </summary>
 public class PlayerControllerTests
 {
+    [Test]
+    public void RequiredComponents_AutoAddedByAttribute()
+    {
+        // Creating a GameObject and adding PlayerController alone should
+        // automatically populate essential components via the RequireComponent
+        // attribute. This guards against null reference errors at runtime.
+        var player = new GameObject("player");
+        player.AddComponent<PlayerController>();
+
+        Assert.IsNotNull(player.GetComponent<Rigidbody2D>(),
+            "Rigidbody2D should be auto-added by RequireComponent");
+        Assert.IsNotNull(player.GetComponent<CapsuleCollider2D>(),
+            "CapsuleCollider2D should be auto-added by RequireComponent");
+        Assert.IsNotNull(player.GetComponent<Animator>(),
+            "Animator should be auto-added by RequireComponent");
+
+        Object.DestroyImmediate(player);
+    }
+
     [Test]
     public void BufferedJump_TriggersAfterLanding()
     {


### PR DESCRIPTION
## Summary
- enforce `Rigidbody2D`, `CapsuleCollider2D` and `Animator` dependencies using `RequireComponent`
- document PlayerController and tests
- add unit test verifying required components are auto-added

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*