### PR TITLE
Add max size limit and async preloading to ObjectPool

### DIFF
--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections;
 using System.Collections.Generic;
 
 /*
@@ -12,6 +13,12 @@ using System.Collections.Generic;
  * CreateNew now reuses a prefab-defined PooledObject component when present,
  * avoiding duplicate components and clarifying that prefabs may include the
  * component for debugging or customised setup.
+ *
+ * NEW IN THIS REVISION:
+ * - Introduced a configurable maxSize limit to cap total pooled instances and
+ *   emit warnings when expansion is requested beyond the cap.
+ * - Replaced Start's synchronous preloading loop with an asynchronous coroutine
+ *   that spreads instantiation across multiple frames to avoid hitches.
  */
 
 /// <summary>
@@ -47,13 +54,22 @@ public class ObjectPool : MonoBehaviour
     /// </summary>
     public int initialSize = 5;
 
+    /// <summary>
+    /// Maximum number of objects the pool is allowed to create. A value of
+    /// <c>0</c> disables the limit and allows unbounded growth. When the cap is
+    /// reached, requests for additional objects will log a warning and return
+    /// <c>null</c>.
+    /// </summary>
+    public int maxSize = 0;
+
     private Queue<PooledObject> objects = new Queue<PooledObject>();
 
     // Delay initialization until Start so prefab can be assigned by spawners
     // before the pool creates its initial objects.
     /// <summary>
     /// Instantiates a set number of objects at start so the pool has
-    /// instances ready for immediate use.
+    /// instances ready for immediate use. Objects are created over multiple
+    /// frames to avoid long hitches during scene load.
     /// </summary>
     void Start()
     {
@@ -64,13 +80,40 @@ public class ObjectPool : MonoBehaviour
         if (prefab == null)
         {
             Debug.LogWarning($"{nameof(ObjectPool)} on {name} has no prefab assigned; no objects were preloaded.");
+            return;
         }
-        else
+
+        // Kick off asynchronous preloading. The coroutine yields after each
+        // instantiation so that heavy creation work is spread across frames and
+        // does not stall gameplay or editor responsiveness.
+        StartCoroutine(PreloadCoroutine());
+    }
+
+    /// <summary>
+    /// Coroutine responsible for lazily creating the initial pool objects. It
+    /// yields after each instantiation so the work is amortised across frames.
+    /// </summary>
+    IEnumerator PreloadCoroutine()
+    {
+        // Determine how many objects we are allowed to preload. Honour the
+        // maxSize limit if one is set; otherwise fall back to initialSize.
+        int target = initialSize;
+        if (maxSize > 0)
         {
-            for (int i = 0; i < initialSize; i++)
+            target = Mathf.Min(initialSize, maxSize);
+        }
+
+        for (int i = 0; i < target; i++)
+        {
+            // Stop preloading early if CreateNew refuses due to size limits.
+            if (CreateNew() == null)
             {
-                CreateNew();
+                yield break;
             }
+
+            // Wait a frame before creating the next object so we avoid frame
+            // spikes from bulk instantiation.
+            yield return null;
         }
     }
 
@@ -86,6 +129,15 @@ public class ObjectPool : MonoBehaviour
     /// </summary>
     PooledObject CreateNew()
     {
+        // Enforce the optional maxSize limit to prevent runaway growth. When
+        // the limit is reached, log a warning and refuse to create more
+        // instances so callers can react appropriately.
+        if (maxSize > 0 && transform.childCount >= maxSize)
+        {
+            Debug.LogWarning($"{nameof(ObjectPool)} on {name} cannot expand beyond max size of {maxSize}.");
+            return null;
+        }
+
         // Instantiate a new object and parent it under the pool so the
         // hierarchy stays clean in the editor.
         GameObject obj = Instantiate(prefab, transform);
@@ -124,12 +176,22 @@ public class ObjectPool : MonoBehaviour
             return null;
         }
 
+        PooledObject po;
         if (objects.Count == 0)
         {
-            CreateNew();
+            // Attempt to expand the pool if all instances are in use. When
+            // maxSize is reached CreateNew will return null, signalling to the
+            // caller that no object is available.
+            po = CreateNew();
+            if (po == null)
+            {
+                return null;
+            }
         }
-
-        PooledObject po = objects.Dequeue();
+        else
+        {
+            po = objects.Dequeue();
+        }
         GameObject obj = po.gameObject;
         obj.transform.SetPositionAndRotation(position, rotation);
         obj.SetActive(true);

--- a/Assets/Tests/EditMode/ObjectPoolTests.cs
+++ b/Assets/Tests/EditMode/ObjectPoolTests.cs
@@ -1,5 +1,7 @@
 using NUnit.Framework;
+using System.Collections;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 /// <summary>
 /// Simple unit tests for the ObjectPool class to ensure instances are
@@ -25,6 +27,73 @@ public class ObjectPoolTests
         // The same instance should be reused after being returned
         Assert.AreSame(first, second);
         Object.DestroyImmediate(first);
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(poolGO);
+    }
+
+    /// <summary>
+    /// Ensures the <see cref="ObjectPool.maxSize"/> cap prevents growth beyond
+    /// the configured limit and that requests beyond the limit yield
+    /// <c>null</c> with a developer-facing warning. This protects games from
+    /// runaway instantiation when pools are misconfigured or objects are never
+    /// returned.
+    /// </summary>
+    [Test]
+    public void GetObject_ReturnsNullWhenExceedingMaxSize()
+    {
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+        pool.maxSize = 1; // Only one instance allowed in total
+
+        // Manually invoke Start to initialise and preload according to the
+        // coroutine. With maxSize set to one, only a single object will be
+        // created.
+        typeof(ObjectPool).GetMethod("Start", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .Invoke(pool, null);
+
+        var first = pool.GetObject(Vector3.zero, Quaternion.identity);
+
+        // The pool has reached its cap; requesting another instance should log
+        // a warning and return null.
+        LogAssert.Expect(LogType.Warning,
+            "ObjectPool on pool cannot expand beyond max size of 1.");
+        var second = pool.GetObject(Vector3.zero, Quaternion.identity);
+        Assert.IsNull(second, "Pool should return null once max size is reached");
+
+        Object.DestroyImmediate(first);
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(poolGO);
+    }
+
+    /// <summary>
+    /// Verifies that preloading is spread across multiple frames by the
+    /// coroutine started in <c>Start</c>. This avoids frame spikes during scene
+    /// initialisation. The test advances the coroutine and ensures that objects
+    /// appear gradually instead of all at once.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator Start_PreloadsOverMultipleFrames()
+    {
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+        pool.initialSize = 2; // Request two objects to observe multi-frame behaviour
+
+        // Start the coroutine-driven preload.
+        typeof(ObjectPool).GetMethod("Start", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .Invoke(pool, null);
+
+        // Immediately after Start only the first object should exist because
+        // the coroutine yields after each instantiation.
+        Assert.AreEqual(1, pool.transform.childCount,
+            "First preload iteration should run immediately");
+
+        // Allow one frame for the coroutine to continue and create the second object.
+        yield return null;
+        Assert.AreEqual(2, pool.transform.childCount,
+            "Second preload iteration should occur on following frame");
+
         Object.DestroyImmediate(pool.prefab);
         Object.DestroyImmediate(poolGO);
     }


### PR DESCRIPTION
## Summary
- add configurable `maxSize` cap for pooled objects with warning on overflow
- preload objects asynchronously over multiple frames to prevent hitches
- extend ObjectPool tests for max-size enforcement and coroutine preloading

## Testing
- `npm test`