### PR TITLE
feat: centralize verbose logging

### DIFF
--- a/Assets/Scripts/AnalyticsManager.cs
+++ b/Assets/Scripts/AnalyticsManager.cs
@@ -6,6 +6,14 @@ using System.Diagnostics;
 using System.Threading;
 
 // -----------------------------------------------------------------------------
+// 2027 update summary
+// -----------------------------------------------------------------------------
+// Routes all analytics logging through LoggingHelper so verbose network
+// diagnostics can be suppressed in production builds while still exposing
+// critical errors to developers.
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
 // 2026 update summary
 // -----------------------------------------------------------------------------
 // Introduces a configurable cap on stored run data to prevent unbounded memory
@@ -295,7 +303,9 @@ public class AnalyticsManager : MonoBehaviour
             string json = JsonUtility.ToJson(new RunCollection { runs = runs.ToArray() });
             if (string.IsNullOrEmpty(remoteEndpoint))
             {
-                Debug.Log("Analytics data: " + json);
+                // Output collected analytics data during development for
+                // troubleshooting but omit in production builds.
+                LoggingHelper.Log("Analytics data: " + json);
                 runs.Clear();
                 PlayerPrefs.DeleteKey("AnalyticsData");
                 break;
@@ -320,10 +330,12 @@ public class AnalyticsManager : MonoBehaviour
             }
             else
             {
-                Debug.LogWarning($"Failed to send analytics attempt {attempt + 1}: {req.Error}");
+                // Warnings surface transient network issues without spamming
+                // release builds.
+                LoggingHelper.LogWarning($"Failed to send analytics attempt {attempt + 1}: {req.Error}");
                 if (attempt++ >= maxRetries)
                 {
-                    Debug.LogWarning("Giving up on analytics send until next attempt");
+                    LoggingHelper.LogWarning("Giving up on analytics send until next attempt");
                     break;
                 }
 
@@ -367,7 +379,7 @@ public class AnalyticsManager : MonoBehaviour
             string json = JsonUtility.ToJson(new RunCollection { runs = runs.ToArray() });
             if (string.IsNullOrEmpty(remoteEndpoint))
             {
-                Debug.Log("Analytics data: " + json);
+                LoggingHelper.Log("Analytics data: " + json);
                 runs.Clear();
                 PlayerPrefs.DeleteKey("AnalyticsData");
                 break;
@@ -384,7 +396,7 @@ public class AnalyticsManager : MonoBehaviour
 
             if (!req.IsDone)
             {
-                Debug.LogWarning("Analytics send timed out");
+                LoggingHelper.LogWarning("Analytics send timed out");
             }
 
             if (req.Result == UnityWebRequest.Result.Success)
@@ -395,7 +407,7 @@ public class AnalyticsManager : MonoBehaviour
             }
             else
             {
-                Debug.LogWarning($"Failed to send analytics attempt {attempt + 1}: {req.Error}");
+                LoggingHelper.LogWarning($"Failed to send analytics attempt {attempt + 1}: {req.Error}");
                 if (attempt++ >= maxRetries)
                     break;
             }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -68,6 +68,11 @@ using System.Collections;
 /// now validates this reference and logs an error when it is absent to help
 /// developers catch misconfigured scenes early.
 /// </remarks>
+/// <remarks>
+/// 2026 update: redirects error logs through <see cref="LoggingHelper"/> so
+/// build configurations can suppress verbose output while still surfacing
+/// critical issues.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -515,7 +520,9 @@ public class GameManager : MonoBehaviour
         if (playerObject == null)
         {
             // Without this reference, we cannot spawn power-ups or perform player-based logic.
-            Debug.LogError("StartGame: Player object reference not set. Skipping starting power-up spawn.");
+            // Even when verbose logging is disabled this critical error is
+            // surfaced so misconfigured scenes can be diagnosed.
+            LoggingHelper.LogError("StartGame: Player object reference not set. Skipping starting power-up spawn.");
         }
         else if (startingCount > 0 && startingPowerUps != null && startingPowerUps.Length > 0)
         {

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -4,6 +4,11 @@
 // manager now includes a progress reporting API so loading screens can display
 // combined progress while assets stream asynchronously. This complements the
 // existing show/hide indicator previously added for addressable loading.
+//
+// 2026 addition summary
+// Added LoggingHelper usage to gate nonessential Debug output behind a global
+// flag so production builds can remain silent while developers retain verbose
+// information inside the editor.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -91,7 +96,9 @@ public class UIManager : MonoBehaviour
             }
             else
             {
-                Debug.LogWarning("MobileUI prefab not found in Resources/UI");
+                // Verbose logging alerts developers if the expected mobile
+                // prefab is missing but remains silent in production builds.
+                LoggingHelper.LogWarning("MobileUI prefab not found in Resources/UI");
             }
         }
     }
@@ -499,14 +506,18 @@ public class UIManager : MonoBehaviour
 #if UNITY_STANDALONE
         if (downloadedPacks == null || downloadedPacks.Count == 0)
         {
-            Debug.LogWarning("No downloaded workshop items available.");
+            // Inform developers when no workshop items were discovered while
+            // keeping release builds free of noise.
+            LoggingHelper.LogWarning("No downloaded workshop items available.");
             return;
         }
 
         string packPath = downloadedPacks[0];
         if (!Directory.Exists(packPath))
         {
-            Debug.LogError("Workshop path not found: " + packPath);
+            // Critical error logs still surface even when verbose logging is
+            // disabled to ensure player issues are reported.
+            LoggingHelper.LogError("Workshop path not found: " + packPath);
             return;
         }
 
@@ -525,7 +536,7 @@ public class UIManager : MonoBehaviour
                 var bundle = AssetBundle.LoadFromFile(bundlePath);
                 if (bundle == null)
                 {
-                    Debug.LogError("Failed to load AssetBundle: " + bundlePath);
+                    LoggingHelper.LogError("Failed to load AssetBundle: " + bundlePath);
                     return;
                 }
 
@@ -540,13 +551,15 @@ public class UIManager : MonoBehaviour
                         if (sr != null)
                         {
                             sr.sprite = bg;
-                            Debug.Log("Applied background sprite from bundle.");
+                            // This message helps during development to verify
+                            // the correct assets are applied.
+                            LoggingHelper.Log("Applied background sprite from bundle.");
                         }
                     }
                 }
                 else
                 {
-                    Debug.LogWarning("BackgroundSprite not found in bundle.");
+                    LoggingHelper.LogWarning("BackgroundSprite not found in bundle.");
                 }
 
                 // Example prefab instantiation
@@ -554,7 +567,7 @@ public class UIManager : MonoBehaviour
                 if (prefab != null)
                 {
                     Instantiate(prefab, Vector3.zero, Quaternion.identity);
-                    Debug.Log("Instantiated prefab from bundle.");
+                    LoggingHelper.Log("Instantiated prefab from bundle.");
                 }
 
                 bundle.Unload(false);
@@ -577,24 +590,24 @@ public class UIManager : MonoBehaviour
                             if (sr != null)
                             {
                                 sr.sprite = sprite;
-                                Debug.Log("Applied background sprite from file: " + Path.GetFileName(pngPath));
+                                LoggingHelper.Log("Applied background sprite from file: " + Path.GetFileName(pngPath));
                             }
                         }
                     }
                     else
                     {
-                        Debug.LogError("Failed to load texture from " + pngPath);
+                        LoggingHelper.LogError("Failed to load texture from " + pngPath);
                     }
                 }
                 else
                 {
-                    Debug.LogWarning("No asset bundle or supported files found in " + packPath);
+                    LoggingHelper.LogWarning("No asset bundle or supported files found in " + packPath);
                 }
             }
         }
         catch (System.Exception ex)
         {
-            Debug.LogError("Error applying workshop item: " + ex.Message);
+            LoggingHelper.LogError("Error applying workshop item: " + ex.Message);
         }
 #endif
     }

--- a/Assets/Scripts/Utilities/LoggingHelper.cs
+++ b/Assets/Scripts/Utilities/LoggingHelper.cs
@@ -1,0 +1,77 @@
+// LoggingHelper.cs
+// -----------------------------------------------------------------------------
+// Centralized wrapper around Unity's Debug class. The helper gates verbose
+// logging behind a single toggle so development builds can emit rich trace
+// information while production builds remain silent. Error logging always
+// occurs so critical issues surface during play.
+// -----------------------------------------------------------------------------
+
+using UnityEngine;
+
+/// <summary>
+/// Provides a single point of control for logging throughout the project.
+/// Verbose output can be disabled globally for release builds by clearing
+/// <see cref="VerboseEnabled"/>. Error messages always log regardless of the
+/// flag. Usage example:
+/// <code>
+/// LoggingHelper.Log("Loaded profile");
+/// LoggingHelper.LogWarning("Missing texture");
+/// LoggingHelper.LogError("Save failed");
+/// </code>
+/// </summary>
+public static class LoggingHelper
+{
+    /// <summary>
+    /// Indicates whether standard and warning logs should be emitted. Defaults
+    /// to true inside the Unity Editor so developers automatically see messages
+    /// during iteration, but can be toggled off at runtime by tests or build
+    /// scripts. Release builds initialize this to false to avoid console noise.
+    /// </summary>
+    public static bool VerboseEnabled =
+#if UNITY_EDITOR
+        true;
+#else
+        false;
+#endif
+
+    /// <summary>
+    /// Emits an informational message when <see cref="VerboseEnabled"/> is true.
+    /// No exception is thrown if the message is null; nothing logs instead.
+    /// </summary>
+    /// <param name="message">Content to send to the Unity console.</param>
+    public static void Log(string message)
+    {
+        // Guard against unnecessary string formatting when logs are disabled.
+        if (VerboseEnabled && message != null)
+        {
+            Debug.Log(message);
+        }
+    }
+
+    /// <summary>
+    /// Emits a warning message when <see cref="VerboseEnabled"/> is true.
+    /// </summary>
+    /// <param name="message">Content to send to the Unity console.</param>
+    public static void LogWarning(string message)
+    {
+        // Similar check to <see cref="Log"/> to avoid overhead in release.
+        if (VerboseEnabled && message != null)
+        {
+            Debug.LogWarning(message);
+        }
+    }
+
+    /// <summary>
+    /// Emits an error message regardless of the verbose flag. Errors are always
+    /// important for diagnosing issues so they are never suppressed.
+    /// </summary>
+    /// <param name="message">Content to send to the Unity console.</param>
+    public static void LogError(string message)
+    {
+        if (message != null)
+        {
+            Debug.LogError(message);
+        }
+    }
+}
+

--- a/Assets/Tests/EditMode/AnalyticsManagerTests.cs
+++ b/Assets/Tests/EditMode/AnalyticsManagerTests.cs
@@ -4,12 +4,21 @@ using UnityEngine.Networking;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using UnityEngine.TestTools; // For LogAssert to verify logging
 
 // -----------------------------------------------------------------------------
 // 2026 addition summary
 // -----------------------------------------------------------------------------
 // Introduces tests verifying that the AnalyticsManager enforces the configurable
 // run history cap by trimming the oldest entries when the limit is exceeded.
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// 2027 addition summary
+// -----------------------------------------------------------------------------
+// Extends coverage by asserting that failed uploads log through the centralized
+// LoggingHelper, guaranteeing that diagnostic warnings remain testable and
+// controllable via a single flag.
 // -----------------------------------------------------------------------------
 
 /// <summary>
@@ -72,6 +81,9 @@ public class AnalyticsManagerTests
         am.remoteEndpoint = "http://example.com";
         am.maxRetries = 0;
         am.mockResults.Enqueue(UnityWebRequest.Result.ProtocolError); // fail once
+
+        // Expect a warning log about the failed send through LoggingHelper.
+        LogAssert.Expect(LogType.Warning, "Failed to send analytics attempt 1: error");
 
         am.LogRun(5f, 10, true);
 

--- a/Assets/Tests/EditMode/LoggingHelperTests.cs
+++ b/Assets/Tests/EditMode/LoggingHelperTests.cs
@@ -1,0 +1,68 @@
+// LoggingHelperTests.cs
+// -----------------------------------------------------------------------------
+// Validates the behavior of the centralized LoggingHelper utility. The tests
+// ensure that verbose messages honor the global toggle while error logs always
+// surface. Run via the Unity Test Runner in edit mode.
+// -----------------------------------------------------------------------------
+
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// Unit tests confirming that <see cref="LoggingHelper"/> correctly routes
+/// messages to Unity's console based on the configured verbosity. These tests
+/// guard against regressions where verbose output might leak into production
+/// builds or critical errors might be inadvertently suppressed.
+/// </summary>
+public class LoggingHelperTests
+{
+    /// <summary>
+    /// Reset verbosity to on before each test so cases can individually toggle
+    /// it as needed without cross-test interference.
+    /// </summary>
+    [SetUp]
+    public void EnableVerboseByDefault()
+    {
+        LoggingHelper.VerboseEnabled = true;
+    }
+
+    /// <summary>
+    /// When verbose logging is enabled, informational messages should appear in
+    /// the Unity console. The LogAssert helper verifies that the expected entry
+    /// is emitted.
+    /// </summary>
+    [Test]
+    public void Log_EmitsMessage_WhenVerboseEnabled()
+    {
+        // Expect a simple log and then invoke the helper.
+        LogAssert.Expect(LogType.Log, "test message");
+        LoggingHelper.Log("test message");
+    }
+
+    /// <summary>
+    /// Disabling the verbose flag should prevent standard logs from appearing.
+    /// NoUnexpectedReceived ensures the console remains clean after invoking
+    /// the helper.
+    /// </summary>
+    [Test]
+    public void Log_DoesNotEmit_WhenVerboseDisabled()
+    {
+        LoggingHelper.VerboseEnabled = false;
+        LoggingHelper.Log("should be silent");
+        LogAssert.NoUnexpectedReceived();
+    }
+
+    /// <summary>
+    /// Error logs must always surface regardless of verbosity so players and
+    /// developers are alerted to critical issues.
+    /// </summary>
+    [Test]
+    public void LogError_AlwaysEmits()
+    {
+        LoggingHelper.VerboseEnabled = false;
+        LogAssert.Expect(LogType.Error, "important problem");
+        LoggingHelper.LogError("important problem");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add LoggingHelper utility to gate verbose Debug logs
- route UIManager, GameManager and AnalyticsManager messages through helper
- test LoggingHelper behavior and verify analytics warnings log via helper

## Testing
- `mcs -r:/usr/lib/cli/nunit.framework-2.6.3/nunit.framework.dll -target:library Assets/Tests/EditMode/LoggingHelperTests.cs` *(fails: The type or namespace name `UnityEngine` could not be found)*
- `npm test`