### PR TITLE
Propagate leaderboard communication status

### DIFF
--- a/Assets/Scripts/LeaderboardClient.cs
+++ b/Assets/Scripts/LeaderboardClient.cs
@@ -11,7 +11,9 @@ using UnityEngine.Networking;
 // are guarded by a runtime HTTPS check to prevent accidental insecure traffic.
 // Additional revisions introduce request timeouts, automatic retries with
 // exponential backoff, and richer error reporting so callers can distinguish
-// between client and server failures.
+// between client and server failures. The latest update exposes explicit
+// success flags from upload and download operations so the UI can present
+// meaningful error messages when network communication fails.
 
 /// <summary>
 /// Client for a simple REST-based leaderboard service used when Steamworks
@@ -84,14 +86,19 @@ public class LeaderboardClient : MonoBehaviour
     /// <summary>
     /// Uploads <paramref name="score"/> associated with <see cref="playerName"/>.
     /// The request body is JSON of the form {"name":"Player","score":100}.
+    /// A callback reports whether the upload ultimately succeeded so callers
+    /// can react to network failures.
     /// </summary>
-    public IEnumerator UploadScore(int score)
+    /// <param name="score">Score value to submit.</param>
+    /// <param name="onComplete">Optional callback receiving a success flag.</param>
+    public IEnumerator UploadScore(int score, System.Action<bool> onComplete = null)
     {
         // Ensure serviceUrl is configured and uses HTTPS before attempting
         // to communicate with the leaderboard. Failing to validate here would
         // allow insecure plaintext traffic or null requests.
         if (!IsServiceUrlSecure())
         {
+            onComplete?.Invoke(false);
             yield break;
         }
 
@@ -129,16 +136,23 @@ public class LeaderboardClient : MonoBehaviour
         {
             Debug.LogWarning("Failed to upload score to leaderboard");
         }
+        // Notify caller of the final outcome. This enables UI elements to
+        // display error messages or retry options.
+        onComplete?.Invoke(success);
     }
 
     /// <summary>
     /// Retrieves the top scores from the service. If the request fails or
     /// returns invalid data, the local high score from
-    /// <see cref="SaveGameManager"/> is provided instead.
+    /// <see cref="SaveGameManager"/> is provided instead. The callback also
+    /// receives a success flag indicating whether remote communication
+    /// succeeded so callers can present error messages.
     /// </summary>
-    public IEnumerator GetTopScores(System.Action<List<ScoreEntry>> callback)
+    /// <param name="callback">Invoked with the retrieved scores and a success flag.</param>
+    public virtual IEnumerator GetTopScores(System.Action<List<ScoreEntry>, bool> callback)
     {
-        List<ScoreEntry> result = null;
+        List<ScoreEntry> result = null; // Final list of scores to return
+        bool success = false;           // Tracks whether the remote request succeeded
 
         // Validate serviceUrl to enforce secure communication. If invalid,
         // immediately return the local high score without issuing any web
@@ -148,7 +162,6 @@ public class LeaderboardClient : MonoBehaviour
             string url = serviceUrl.TrimEnd('/') + "/scores";
             const int maxRetries = 3;
             int attempt = 0;
-            bool success = false;
             string text = null;
             while (attempt < maxRetries && !success)
             {
@@ -174,14 +187,19 @@ public class LeaderboardClient : MonoBehaviour
         }
 
         // Fallback when the serviceUrl is invalid, the request fails, or the
-        // response is empty/invalid.
+        // response is empty/invalid. In these scenarios the operation is
+        // considered unsuccessful even though a list is still returned.
         if (result == null || result.Count == 0)
         {
             int local = SaveGameManager.Instance != null ? SaveGameManager.Instance.HighScore : 0;
             string name = LocalizationManager.Get("leaderboard_local_player");
             result = new List<ScoreEntry> { new ScoreEntry { name = name, score = local } };
+            success = false;
         }
-        callback?.Invoke(result);
+
+        // Callback receives both the scores to display and whether they came
+        // from the remote service (true) or a local fallback (false).
+        callback?.Invoke(result, success);
     }
 
     /// <summary>

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -9,6 +9,10 @@
 // Added LoggingHelper usage to gate nonessential Debug output behind a global
 // flag so production builds can remain silent while developers retain verbose
 // information inside the editor.
+//
+// 2029 update summary
+// When leaderboard communication fails a localized error message is now shown
+// in the UI so players receive feedback instead of an empty panel.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -344,6 +348,8 @@ public class UIManager : MonoBehaviour
                 }
                 else if (leaderboardClient != null)
                 {
+                    // Steam call failed; fall back to HTTP client and report
+                    // success status so the UI can surface any errors.
                     StartCoroutine(leaderboardClient.GetTopScores(DisplayScores));
                 }
             });
@@ -360,10 +366,34 @@ public class UIManager : MonoBehaviour
 #endif
     }
 
-    // Helper to format and display leaderboard entries in the panel
-    private void DisplayScores(List<LeaderboardClient.ScoreEntry> scores)
+    // Helper to format and display leaderboard entries in the panel.
+    // Marked public so unit tests and other systems can invoke the formatting
+    // logic directly without relying on coroutines.
+    public void DisplayScores(List<LeaderboardClient.ScoreEntry> scores, bool success)
     {
-        if (leaderboardText != null && scores != null)
+        if (leaderboardText == null)
+        {
+            return;
+        }
+
+        // When the client reports failure, show a user-friendly message instead
+        // of blank text so players understand the leaderboard could not be
+        // reached. A localized string is used when available with an English
+        // fallback otherwise.
+        if (!success)
+        {
+            string msg = LocalizationManager.Get("leaderboard_error");
+            if (msg == "leaderboard_error")
+            {
+                msg = "Failed to load leaderboard.";
+            }
+            leaderboardText.text = msg;
+            return;
+        }
+
+        // Successful retrieval: format the list of scores according to the
+        // localized entry pattern.
+        if (scores != null)
         {
             var sb = new System.Text.StringBuilder();
             string fmt = LocalizationManager.Get("leaderboard_entry_format");

--- a/Assets/Tests/EditMode/LeaderboardClientTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientTests.cs
@@ -90,12 +90,14 @@ public class LeaderboardClientTests
         client.succeed = false; // simulate failure
 
         List<LeaderboardClient.ScoreEntry> result = null;
-        var routine = client.GetTopScores(list => result = list);
+        bool success = true;
+        var routine = client.GetTopScores((list, ok) => { result = list; success = ok; });
         while (routine.MoveNext()) { }
 
         Assert.IsNotNull(result);
         Assert.AreEqual(1, result.Count);
         Assert.AreEqual(5, result[0].score);
+        Assert.IsFalse(success, "Callback should report failure when falling back to local scores");
         Object.DestroyImmediate(go);
         Object.DestroyImmediate(saveObj);
     }
@@ -119,12 +121,39 @@ public class LeaderboardClientTests
 
         LocalizationManager.SetLanguage("es");
         List<LeaderboardClient.ScoreEntry> result = null;
-        var routine = client.GetTopScores(list => result = list);
+        bool success = true;
+        var routine = client.GetTopScores((list, ok) => { result = list; success = ok; });
         while (routine.MoveNext()) { }
 
         Assert.AreEqual("Local ES", result[0].name);
+        Assert.IsFalse(success, "Localized fallback should still report failure");
         Object.DestroyImmediate(go);
         Object.DestroyImmediate(saveObj);
+    }
+
+    /// <summary>
+    /// Successful web requests should report a positive status through the
+    /// callback so callers know remote data was used.
+    /// </summary>
+    [Test]
+    public void GetTopScores_ReportsSuccess()
+    {
+        var go = new GameObject("lbOk");
+        var client = go.AddComponent<DummyClient>();
+        client.serviceUrl = "https://example.com";
+        client.succeed = true;
+        client.payload = "[{\"name\":\"A\",\"score\":1}]"; // valid JSON array
+
+        List<LeaderboardClient.ScoreEntry> result = null;
+        bool success = false;
+        var routine = client.GetTopScores((list, ok) => { result = list; success = ok; });
+        while (routine.MoveNext()) { }
+
+        Assert.IsTrue(success, "Callback should report success when request completes");
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Count);
+
+        Object.DestroyImmediate(go);
     }
 
     /// <summary>
@@ -162,12 +191,42 @@ public class LeaderboardClientTests
         var client = go.AddComponent<RetryClient>();
         client.serviceUrl = "https://example.com"; // pass HTTPS validation
         client.succeedOn = 2; // Fail first attempt, succeed on second
+        bool result = false;
 
-        var routine = client.UploadScore(10);
+        var routine = client.UploadScore(10, ok => result = ok);
         while (routine.MoveNext()) { }
 
         Assert.AreEqual(2, client.calls, "Upload should retry once before succeeding");
         Assert.AreEqual(10, client.lastTimeout, "Request timeout should be applied");
+        Assert.IsTrue(result, "Callback should report success after retries");
+
+        Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// UploadScore should surface failure through its callback so callers can
+    /// react appropriately (e.g., display an error message).
+    /// </summary>
+    [Test]
+    public void UploadScore_ReportsStatus()
+    {
+        var go = new GameObject("lbStatus");
+        var client = go.AddComponent<DummyClient>();
+        client.serviceUrl = "https://example.com";
+
+        // Simulate successful upload
+        client.succeed = true;
+        bool success = false;
+        var routine = client.UploadScore(1, ok => success = ok);
+        while (routine.MoveNext()) { }
+        Assert.IsTrue(success, "Callback should report success when request succeeds");
+
+        // Simulate failure
+        client.succeed = false;
+        success = true;
+        routine = client.UploadScore(1, ok => success = ok);
+        while (routine.MoveNext()) { }
+        Assert.IsFalse(success, "Callback should report failure when request fails");
 
         Object.DestroyImmediate(go);
     }

--- a/Assets/Tests/EditMode/UIManagerTests.cs
+++ b/Assets/Tests/EditMode/UIManagerTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Tests for <see cref="UIManager"/> verifying that leaderboard errors are
+/// surfaced to the player through a clear message. The tests execute the
+/// formatting logic directly to avoid dependency on Unity coroutines.
+/// </summary>
+public class UIManagerTests
+{
+    /// <summary>
+    /// When the leaderboard callback reports failure the UI should present a
+    /// friendly message instead of leaving the panel blank. This helps players
+    /// understand that scores could not be retrieved rather than assuming there
+    /// are none.
+    /// </summary>
+    [Test]
+    public void DisplayScores_ShowsErrorMessageOnFailure()
+    {
+        // Prepare a minimal UI hierarchy containing the text element that will
+        // display either scores or the error message.
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+        var textObj = new GameObject("txt");
+        var text = textObj.AddComponent<Text>();
+        ui.leaderboardText = text;
+
+        // Simulate a failed leaderboard retrieval.
+        ui.DisplayScores(null, false);
+
+        // The text should now contain the human readable error string.
+        Assert.AreEqual("Failed to load leaderboard.", text.text);
+
+        Object.DestroyImmediate(textObj);
+        Object.DestroyImmediate(uiObj);
+    }
+}
+


### PR DESCRIPTION
## Summary
- surface upload and download success flags from `LeaderboardClient` so callers know when the network failed
- show a localized error message in the leaderboard UI when scores cannot be fetched
- add tests verifying callback statuses and UI error handling

## Testing
- `npm test`