### PR TITLE
Ensure mobile canvas persists and cleans up

### DIFF
--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -13,6 +13,12 @@
 // 2029 update summary
 // When leaderboard communication fails a localized error message is now shown
 // in the UI so players receive feedback instead of an empty panel.
+//
+// 2031 update summary
+// The mobile-specific canvas instantiated on handheld devices is now marked
+// to persist across scene loads and is explicitly destroyed when the manager
+// itself is torn down. This prevents duplicate canvases from accumulating
+// as scenes transition while still ensuring the mobile UI remains available.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -97,6 +103,9 @@ public class UIManager : MonoBehaviour
             if (prefab != null)
             {
                 mobileCanvas = Instantiate(prefab);
+                // Keep the mobile canvas alive when new scenes load so touch
+                // controls remain available during transitions.
+                DontDestroyOnLoad(mobileCanvas);
             }
             else
             {
@@ -104,6 +113,28 @@ public class UIManager : MonoBehaviour
                 // prefab is missing but remains silent in production builds.
                 LoggingHelper.LogWarning("MobileUI prefab not found in Resources/UI");
             }
+        }
+    }
+
+    /// <summary>
+    /// Cleans up persistent UI when this manager is destroyed. The mobile
+    /// canvas is marked as "DontDestroyOnLoad" so scene changes do not remove
+    /// it automatically. Destroying it here prevents multiple copies from
+    /// lingering if a new <see cref="UIManager"/> is created after a
+    /// transition. The singleton instance reference is also cleared so future
+    /// instances can initialize correctly.
+    /// </summary>
+    void OnDestroy()
+    {
+        if (mobileCanvas != null)
+        {
+            Destroy(mobileCanvas);
+            mobileCanvas = null;
+        }
+
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
 

--- a/Assets/Tests/EditMode/TouchInputManagerTests.cs
+++ b/Assets/Tests/EditMode/TouchInputManagerTests.cs
@@ -1,11 +1,15 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
+using System.Linq;
 
 /// <summary>
 /// Tests for the new touch input helpers exposed through InputManager.
 /// They ensure the flags set by TouchInputManager are consumed correctly
-/// by the existing Get* methods.
+/// by the existing Get* methods. A regression test also verifies that the
+/// mobile‑specific canvas created by <see cref="UIManager"/> does not
+/// duplicate itself when scenes change, which would otherwise clutter the
+/// hierarchy with redundant UI objects.
 /// </summary>
 public class TouchInputManagerTests
 {
@@ -103,5 +107,49 @@ public class TouchInputManagerTests
         Object.DestroyImmediate(player);
         Object.DestroyImmediate(ground);
         Object.DestroyImmediate(gmObj);
+    }
+
+    [Test]
+    public void MobileCanvas_DoesNotDuplicateAcrossScenes()
+    {
+        // Instantiate the first UIManager to simulate the initial scene.
+        var uiObj1 = new GameObject("ui1");
+        var ui1 = uiObj1.AddComponent<UIManager>();
+
+        // Manually create and register a mobile canvas as if Awake() had run
+        // on a mobile platform. Tests execute in the editor where
+        // Application.isMobilePlatform is false, so we inject the canvas via
+        // reflection to exercise the cleanup logic.
+        var prefab = Resources.Load<GameObject>("UI/MobileUI");
+        var canvas1 = Object.Instantiate(prefab);
+        typeof(UIManager)
+            .GetField("mobileCanvas", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(ui1, canvas1);
+        Object.DontDestroyOnLoad(canvas1);
+
+        // Destroy the first manager to mimic a scene transition. Without a
+        // cleanup method this would leave the mobile canvas behind.
+        Object.DestroyImmediate(uiObj1);
+
+        // Create a second manager as would happen when a new scene loads.
+        var uiObj2 = new GameObject("ui2");
+        var ui2 = uiObj2.AddComponent<UIManager>();
+        var canvas2 = Object.Instantiate(prefab);
+        typeof(UIManager)
+            .GetField("mobileCanvas", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(ui2, canvas2);
+        Object.DontDestroyOnLoad(canvas2);
+
+        // Count the mobile canvases that survived the transition. Only the
+        // second one should remain because OnDestroy should remove the first.
+        var mobileCanvases = Object.FindObjectsOfType<Canvas>()
+            .Where(c => c.gameObject.name.Contains("MobileUI"));
+        Assert.AreEqual(1, mobileCanvases.Count(),
+            "Only one mobile canvas should exist after recreating UIManager");
+
+        // Clean up objects created during the test to keep the editor state
+        // pristine for subsequent tests.
+        Object.DestroyImmediate(canvas2);
+        Object.DestroyImmediate(uiObj2);
     }
 }


### PR DESCRIPTION
## Summary
- persist mobile UI canvas across scene loads and destroy it when UIManager is torn down
- add regression test confirming only one mobile canvas exists after scene transitions

## Testing
- `npm test`