### PR TITLE
feat: add network activity spinner

### DIFF
--- a/Assets/Scripts/AnalyticsManager.cs
+++ b/Assets/Scripts/AnalyticsManager.cs
@@ -289,6 +289,9 @@ public class AnalyticsManager : MonoBehaviour
         isSending = true;
         int attempt = 0;
 
+        // Display spinner so players know analytics are being transmitted.
+        UIManager.Instance?.ShowNetworkSpinner();
+
         while (runs.Count > 0)
         {
             // Skip sending when offline and wait before retrying.
@@ -344,6 +347,9 @@ public class AnalyticsManager : MonoBehaviour
             }
         }
 
+        // Hide spinner once all upload attempts conclude.
+        UIManager.Instance?.HideNetworkSpinner();
+
         isSending = false;
         uploadRoutine = null;
         UploadFinished?.Invoke(runs.Count == 0);
@@ -361,6 +367,9 @@ public class AnalyticsManager : MonoBehaviour
 
         isSending = true;
         int attempt = 0;
+
+        // Display spinner to communicate the blocking network activity.
+        UIManager.Instance?.ShowNetworkSpinner();
 
         while (runs.Count > 0)
         {
@@ -412,6 +421,9 @@ public class AnalyticsManager : MonoBehaviour
                     break;
             }
         }
+
+        // Ensure the spinner is hidden once the blocking send finishes.
+        UIManager.Instance?.HideNetworkSpinner();
 
         isSending = false;
         UploadFinished?.Invoke(runs.Count == 0);

--- a/Assets/Scripts/LeaderboardClient.cs
+++ b/Assets/Scripts/LeaderboardClient.cs
@@ -102,6 +102,9 @@ public class LeaderboardClient : MonoBehaviour
             yield break;
         }
 
+        // Show a visual indicator so players know a network operation is in progress.
+        UIManager.Instance?.ShowNetworkSpinner();
+
         string url = serviceUrl.TrimEnd('/') + "/scores";
         string json = JsonUtility.ToJson(new ScoreEntry { name = playerName, score = score });
 
@@ -139,6 +142,9 @@ public class LeaderboardClient : MonoBehaviour
         // Notify caller of the final outcome. This enables UI elements to
         // display error messages or retry options.
         onComplete?.Invoke(success);
+
+        // Hide the network activity spinner now that the request has finished.
+        UIManager.Instance?.HideNetworkSpinner();
     }
 
     /// <summary>
@@ -159,6 +165,9 @@ public class LeaderboardClient : MonoBehaviour
         // requests.
         if (IsServiceUrlSecure())
         {
+            // Network request will occur, so show the spinner to inform the user.
+            UIManager.Instance?.ShowNetworkSpinner();
+
             string url = serviceUrl.TrimEnd('/') + "/scores";
             const int maxRetries = 3;
             int attempt = 0;
@@ -184,6 +193,9 @@ public class LeaderboardClient : MonoBehaviour
             {
                 result = ParseScores(text);
             }
+
+            // Hide the spinner once the request finishes regardless of outcome.
+            UIManager.Instance?.HideNetworkSpinner();
         }
 
         // Fallback when the serviceUrl is invalid, the request fails, or the

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -19,6 +19,11 @@
 // to persist across scene loads and is explicitly destroyed when the manager
 // itself is torn down. This prevents duplicate canvases from accumulating
 // as scenes transition while still ensuring the mobile UI remains available.
+//
+// 2034 update summary
+// Introduces a dedicated network-activity spinner so players receive visual
+// feedback while HTTP requests or other online operations are in progress.
+// Other managers can toggle the spinner via new public methods exposed below.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -71,6 +76,8 @@ public class UIManager : MonoBehaviour
     public GameObject loadingPanel;
     [Tooltip("Optional slider visualizing loading progress from 0 to 1.")]
     public Slider loadingProgressBar;
+    [Tooltip("Small icon or status text shown while network calls are pending.")]
+    public GameObject networkSpinner;
     [Tooltip("External form URL for player feedback. Leave blank to hide the button.")]
     public string feedbackUrl = "";
 
@@ -232,6 +239,35 @@ public class UIManager : MonoBehaviour
     /// </summary>
     public float LoadingProgress => loadingProgress;
 
+    /// <summary>
+    /// Shows a small spinner or status label to indicate that a network
+    /// operation is currently in progress. Network-related classes call this
+    /// before initiating web requests so players receive immediate visual
+    /// feedback. The spinner remains visible until
+    /// <see cref="HideNetworkSpinner"/> is invoked.
+    /// </summary>
+    public void ShowNetworkSpinner()
+    {
+        if (networkSpinner != null)
+        {
+            networkSpinner.SetActive(true);
+        }
+    }
+
+    /// <summary>
+    /// Hides the network activity spinner once all outstanding network
+    /// operations have completed. Callers are responsible for pairing each
+    /// <see cref="ShowNetworkSpinner"/> invocation with this method to ensure
+    /// the spinner accurately reflects current activity.
+    /// </summary>
+    public void HideNetworkSpinner()
+    {
+        if (networkSpinner != null)
+        {
+            networkSpinner.SetActive(false);
+        }
+    }
+
 #if UNITY_STANDALONE
     private List<string> downloadedPacks = new List<string>();
 #endif
@@ -271,6 +307,7 @@ public class UIManager : MonoBehaviour
         HidePanelImmediate(shopPanel);
         HidePanelImmediate(settingsPanel);
         HidePanelImmediate(loadingPanel);
+        HidePanelImmediate(networkSpinner);
         if (GameManager.Instance != null)
         {
             GameManager.Instance.SetUIManager(this);

--- a/Assets/Scripts/WorkshopManager.cs
+++ b/Assets/Scripts/WorkshopManager.cs
@@ -193,6 +193,9 @@ public class WorkshopManager : MonoBehaviour
             yield break;
         }
 
+        // Display both the general loading indicator and the new network spinner
+        // so users know an online fetch is occurring.
+        UIManager.Instance?.ShowNetworkSpinner();
         UIManager.Instance?.ShowLoadingIndicator();
         AsyncOperationHandle<T> handle = Addressables.LoadAssetAsync<T>(address);
         yield return handle;
@@ -200,6 +203,7 @@ public class WorkshopManager : MonoBehaviour
         callback?.Invoke(result);
         Addressables.Release(handle);
         UIManager.Instance?.HideLoadingIndicator();
+        UIManager.Instance?.HideNetworkSpinner();
     }
 #endif
 }

--- a/Assets/Tests/EditMode/AnalyticsManagerTests.cs
+++ b/Assets/Tests/EditMode/AnalyticsManagerTests.cs
@@ -67,6 +67,45 @@ public class AnalyticsManagerTests
         }
     }
 
+    /// <summary>
+    /// Analytics manager subclass that exposes a deterministic web request
+    /// yielding once to simulate an asynchronous upload for spinner testing.
+    /// </summary>
+    private class SpinnerAnalyticsManager : AnalyticsManager
+    {
+        public Queue<UnityWebRequest.Result> mockResults = new Queue<UnityWebRequest.Result>();
+
+        protected override IWebRequest CreateWebRequest(string url, byte[] body)
+        {
+            return new SpinnerRequest(mockResults);
+        }
+
+        protected override YieldInstruction RetryDelay(float seconds)
+        {
+            return null; // skip waits in tests
+        }
+
+        private class SpinnerRequest : IWebRequest
+        {
+            private readonly Queue<UnityWebRequest.Result> results;
+            public SpinnerRequest(Queue<UnityWebRequest.Result> results)
+            {
+                this.results = results;
+            }
+
+            public float UploadProgress => 1f;
+            public bool IsDone => true;
+            public UnityWebRequest.Result Result { get; private set; }
+            public string Error => null;
+
+            public IEnumerator Send()
+            {
+                yield return null; // simulate network delay
+                Result = results.Dequeue();
+            }
+        }
+    }
+
     [SetUp]
     public void ClearPrefs()
     {
@@ -172,6 +211,41 @@ public class AnalyticsManagerTests
         Assert.AreEqual(3f, (float)distanceField.GetValue(firstRun));
 
         Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// The network spinner should reflect analytics upload activity so players
+    /// are aware when data is being transmitted.
+    /// </summary>
+    [Test]
+    public void UploadLoop_TogglesNetworkSpinner()
+    {
+        // Setup UI manager and spinner object.
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+        ui.networkSpinner = new GameObject("spinner");
+
+        // Configure analytics manager with a single run and a mock request.
+        var go = new GameObject("amSpin");
+        var am = go.AddComponent<SpinnerAnalyticsManager>();
+        am.remoteEndpoint = "http://example.com"; // non-empty to trigger send
+        am.mockResults.Enqueue(UnityWebRequest.Result.Success);
+        am.LogRun(1f, 0, false);
+
+        var method = typeof(AnalyticsManager).GetMethod("UploadLoop", BindingFlags.NonPublic | BindingFlags.Instance);
+        var routine = (IEnumerator)method.Invoke(am, null);
+
+        // Spinner becomes visible on first iteration of the coroutine.
+        Assert.IsFalse(ui.networkSpinner.activeSelf);
+        Assert.IsTrue(routine.MoveNext());
+        Assert.IsTrue(ui.networkSpinner.activeSelf);
+
+        while (routine.MoveNext()) { }
+        Assert.IsFalse(ui.networkSpinner.activeSelf);
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(ui.networkSpinner);
+        Object.DestroyImmediate(uiObj);
     }
 }
 

--- a/Assets/Tests/EditMode/LeaderboardClientTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientTests.cs
@@ -60,6 +60,19 @@ public class LeaderboardClientTests
         }
     }
 
+    /// <summary>
+    /// Client used to verify that the network spinner is shown during
+    /// asynchronous web requests.
+    /// </summary>
+    private class SpinnerClient : LeaderboardClient
+    {
+        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> cb)
+        {
+            yield return null; // simulate an async web call
+            cb?.Invoke(true, "[]");
+        }
+    }
+
     [Test]
     public void UploadScore_FormatsBody()
     {
@@ -229,6 +242,36 @@ public class LeaderboardClientTests
         Assert.IsFalse(success, "Callback should report failure when request fails");
 
         Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
+    /// Network spinner should appear while leaderboard data downloads and be
+    /// hidden once the coroutine completes.
+    /// </summary>
+    [Test]
+    public void GetTopScores_TogglesNetworkSpinner()
+    {
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+        ui.networkSpinner = new GameObject("spinner");
+
+        var go = new GameObject("lbSpin");
+        var client = go.AddComponent<SpinnerClient>();
+        client.serviceUrl = "https://example.com";
+
+        var routine = client.GetTopScores(null);
+
+        // Spinner should activate on first step of the coroutine.
+        Assert.IsFalse(ui.networkSpinner.activeSelf);
+        Assert.IsTrue(routine.MoveNext());
+        Assert.IsTrue(ui.networkSpinner.activeSelf);
+
+        while (routine.MoveNext()) { }
+        Assert.IsFalse(ui.networkSpinner.activeSelf);
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(ui.networkSpinner);
+        Object.DestroyImmediate(uiObj);
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/WorkshopManagerTests.cs
+++ b/Assets/Tests/EditMode/WorkshopManagerTests.cs
@@ -1,7 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
+using System.Collections;
 using System.Collections.Generic;
+using UnityEngine.TestTools; // Provides LogAssert and UnityTest support
 
 /// <summary>
 /// Unit tests covering early exit behaviour of <see cref="WorkshopManager"/>.
@@ -58,10 +60,50 @@ public class WorkshopManagerTests
     public void SingletonLifecycle_AwakeAndDestroy()
     {
         var go = new GameObject("wm");
-        var wm = go.AddComponent<WorkshopManager>();
+       var wm = go.AddComponent<WorkshopManager>();
         Assert.AreEqual(wm, WorkshopManager.Instance);
         Object.DestroyImmediate(go);
         Assert.IsNull(WorkshopManager.Instance);
+    }
+
+    /// <summary>
+    /// Loading a workshop asset should toggle the network spinner so players
+    /// know that online content is being fetched.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator LoadAddressableRoutine_TogglesNetworkSpinner()
+    {
+        // Prepare UI manager and spinner object.
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+        ui.networkSpinner = new GameObject("spinner");
+
+        var go = new GameObject("wm");
+        var wm = go.AddComponent<WorkshopManager>();
+
+        // Use reflection to invoke the private coroutine with an invalid key.
+        MethodInfo method = typeof(WorkshopManager).GetMethod("LoadAddressableRoutine", BindingFlags.NonPublic | BindingFlags.Instance);
+        MethodInfo generic = method.MakeGenericMethod(typeof(GameObject));
+
+        // Invalid address triggers an error log; capture it to keep test quiet.
+        LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("(Failed|Exception)"));
+
+        var routine = (IEnumerator)generic.Invoke(wm, new object[] { "00000000000000000000000000000000", null });
+
+        Assert.IsFalse(ui.networkSpinner.activeSelf);
+        Assert.IsTrue(routine.MoveNext());
+        Assert.IsTrue(ui.networkSpinner.activeSelf);
+
+        while (routine.MoveNext())
+        {
+            yield return routine.Current;
+        }
+
+        Assert.IsFalse(ui.networkSpinner.activeSelf);
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(ui.networkSpinner);
+        Object.DestroyImmediate(uiObj);
     }
 #else
     [Test]


### PR DESCRIPTION
## Summary
- add network activity spinner to `UIManager`
- show or hide spinner during leaderboard, analytics, and workshop network calls
- test spinner activation using mocked delayed responses

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found)*