### PR TITLE
Handle non-positive rumble durations

### DIFF
--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -33,6 +33,9 @@ using System.Collections;
 /// 2033 fix: shutdown now iterates over all connected gamepads, resetting rumble
 /// on every device so secondary controllers cannot continue vibrating after the
 /// game exits.
+/// 2034 fix: rumble requests with zero or negative duration now abort before
+/// starting a coroutine, ensuring no unnecessary work is scheduled for
+/// instantaneous vibrations.
 /// </summary>
 public static class InputManager
 {
@@ -792,6 +795,13 @@ public static class InputManager
         // negative durations or out-of-range strengths.
         strength = Mathf.Clamp01(strength);
         duration = Mathf.Max(0f, duration);
+
+        // If the caller requested a non-positive duration after clamping, there
+        // is nothing to do. Exiting early avoids creating a coroutine that would
+        // immediately end, keeping runtime overhead low and preventing subtle
+        // bugs from zero-length rumble requests.
+        if (duration <= 0f)
+            return;
 
         // Stop any existing rumble so motor control doesn't overlap between
         // multiple requests.

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -20,6 +20,8 @@ using UnityEngine.TestTools;
 /// rumble is requested, keeping scenes free of unnecessary hidden objects.
 /// 2033 addition: confirms <see cref="InputManager.Shutdown"/> silences every
 /// connected gamepad, not just the current device.
+/// 2034 addition: validates that non-positive duration rumble requests are
+/// ignored, preventing redundant coroutine scheduling.
 /// </summary>
 public class InputManagerTests
 {
@@ -208,6 +210,61 @@ public class InputManagerTests
         FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.IsNotNull(field, "rumbleRoutine field missing");
         Assert.IsNotNull(field.GetValue(null), "TriggerRumble should start a coroutine when a gamepad is present");
+
+        // Clean up so subsequent tests start with a fresh InputManager state.
+        InputManager.Shutdown();
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(InputManager).TypeHandle);
+        InputSystem.RemoveDevice(gamepad);
+    }
+
+    /// <summary>
+    /// Requesting rumble with a zero second duration should be ignored. This
+    /// guards against accidental calls that would otherwise start and stop a
+    /// coroutine immediately, wasting CPU time.
+    /// </summary>
+    [Test]
+    public void TriggerRumble_ZeroDuration_DoesNotStartCoroutine()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        InputManager.SetRumbleEnabled(true);
+
+        // Duration is zero; rumble should be skipped entirely.
+        InputManager.TriggerRumble(0.5f, 0f);
+
+        FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNull(field.GetValue(null),
+            "Rumble coroutine should not start for zero duration requests");
+
+        // Reset InputManager so later tests are not affected by this call.
+        InputManager.Shutdown();
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(InputManager).TypeHandle);
+        InputSystem.RemoveDevice(gamepad);
+    }
+
+    /// <summary>
+    /// Negative durations are clamped to zero and should likewise result in no
+    /// rumble. This ensures callers cannot accidentally schedule invalid
+    /// vibration requests.
+    /// </summary>
+    [Test]
+    public void TriggerRumble_NegativeDuration_DoesNotStartCoroutine()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        InputManager.SetRumbleEnabled(true);
+
+        // Negative duration is clamped to zero; rumble should not begin.
+        InputManager.TriggerRumble(0.5f, -1f);
+
+        FieldInfo field = typeof(InputManager).GetField("rumbleRoutine", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNull(field.GetValue(null),
+            "Rumble coroutine should not start for negative duration requests");
+
+        // Reset InputManager so later tests run in a clean environment.
+        InputManager.Shutdown();
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(InputManager).TypeHandle);
         InputSystem.RemoveDevice(gamepad);
     }
 


### PR DESCRIPTION
## Summary
- skip scheduling rumble coroutine when requested duration clamps to zero
- test that zero or negative duration rumble requests are ignored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a520dc22e483219d2b2dfbc2c8a781