### PR TITLE
Cache parallax background for workshop updates

### DIFF
--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -24,6 +24,12 @@
 // Introduces a dedicated network-activity spinner so players receive visual
 // feedback while HTTP requests or other online operations are in progress.
 // Other managers can toggle the spinner via new public methods exposed below.
+//
+// 2035 update summary
+// Caches the scene's ParallaxBackground so workshop packs can update the
+// background sprite without repeated FindObjectOfType calls. This reduces
+// per-frame allocations and avoids null reference errors when the background
+// is absent.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -81,6 +87,20 @@ public class UIManager : MonoBehaviour
     [Tooltip("External form URL for player feedback. Leave blank to hide the button.")]
     public string feedbackUrl = "";
 
+    /// <summary>
+    /// Cached reference to the level's parallax background. Assign in the
+    /// inspector for manual control or leave empty to have <see cref="Awake"/>
+    /// discover it once at startup.
+    /// </summary>
+    [SerializeField]
+    private ParallaxBackground parallaxBackground;
+
+    /// <summary>
+    /// Read-only accessor used by tests and other systems that need the
+    /// background reference.
+    /// </summary>
+    public ParallaxBackground ParallaxBackground => parallaxBackground;
+
     private const float panelHideDelay = 0.5f; // wait so hide animation can play
 
     // Instantiated at runtime when running on mobile platforms. Holds the
@@ -120,6 +140,13 @@ public class UIManager : MonoBehaviour
                 // prefab is missing but remains silent in production builds.
                 LoggingHelper.LogWarning("MobileUI prefab not found in Resources/UI");
             }
+        }
+
+        // Resolve the parallax background once so subsequent lookups do not
+        // allocate or accidentally miss the object if it appears later.
+        if (parallaxBackground == null)
+        {
+            parallaxBackground = FindObjectOfType<ParallaxBackground>();
         }
     }
 
@@ -642,10 +669,11 @@ public class UIManager : MonoBehaviour
                 Sprite bg = bundle.LoadAsset<Sprite>("BackgroundSprite");
                 if (bg != null)
                 {
-                    var bgObj = FindObjectOfType<ParallaxBackground>();
-                    if (bgObj != null)
+                    // Utilize the cached parallax background to avoid costly
+                    // scene searches each time a workshop item is applied.
+                    if (parallaxBackground != null)
                     {
-                        var sr = bgObj.GetComponent<SpriteRenderer>();
+                        var sr = parallaxBackground.GetComponent<SpriteRenderer>();
                         if (sr != null)
                         {
                             sr.sprite = bg;
@@ -681,10 +709,11 @@ public class UIManager : MonoBehaviour
                     if (tex.LoadImage(data))
                     {
                         Sprite sprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f));
-                        var bgObj = FindObjectOfType<ParallaxBackground>();
-                        if (bgObj != null)
+                        // Use the cached background reference and skip work if
+                        // it is missing from the active scene.
+                        if (parallaxBackground != null)
                         {
-                            var sr = bgObj.GetComponent<SpriteRenderer>();
+                            var sr = parallaxBackground.GetComponent<SpriteRenderer>();
                             if (sr != null)
                             {
                                 sr.sprite = sprite;

--- a/Assets/Tests/EditMode/UIManagerTests.cs
+++ b/Assets/Tests/EditMode/UIManagerTests.cs
@@ -1,6 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.UI;
+using System.Collections.Generic;
+using System.IO;
 
 /// <summary>
 /// Tests for <see cref="UIManager"/> verifying that leaderboard errors are
@@ -35,5 +37,78 @@ public class UIManagerTests
         Object.DestroyImmediate(textObj);
         Object.DestroyImmediate(uiObj);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="UIManager.Awake"/> automatically caches the
+    /// scene's <see cref="ParallaxBackground"/> when the serialized field is
+    /// left unassigned. This avoids repeated FindObjectOfType lookups at
+    /// runtime.
+    /// </summary>
+    [Test]
+    public void Awake_CachesParallaxBackgroundWhenMissing()
+    {
+        // Create a background object that the manager should locate.
+        var bgObj = new GameObject("bg");
+        var bg = bgObj.AddComponent<ParallaxBackground>();
+
+        // Create the UI manager with a null background reference.
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+
+        // Invoke the private Awake method so the caching logic runs.
+        typeof(UIManager).GetMethod("Awake", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .Invoke(ui, null);
+
+        Assert.AreSame(bg, ui.ParallaxBackground, "Awake should cache the background reference exactly once.");
+
+        Object.DestroyImmediate(uiObj);
+        Object.DestroyImmediate(bgObj);
+    }
+
+    /// <summary>
+    /// Ensures that <see cref="UIManager.ApplyFirstWorkshopItem"/> uses the
+    /// cached background reference and succeeds when one is present. The test
+    /// writes a temporary PNG to disk to mimic a workshop pack.
+    /// </summary>
+#if UNITY_STANDALONE
+    [Test]
+    public void ApplyFirstWorkshopItem_UsesCachedBackground()
+    {
+        // Set up a background with a SpriteRenderer to receive the replacement sprite.
+        var bgObj = new GameObject("bg");
+        bgObj.AddComponent<SpriteRenderer>();
+        var bg = bgObj.AddComponent<ParallaxBackground>();
+
+        // Create the UI manager and assign the background via reflection to
+        // simulate inspector wiring.
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+        typeof(UIManager).GetField("parallaxBackground", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(ui, bg);
+
+        // Create a temporary directory containing a PNG so the method's fallback
+        // path executes.
+        string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        string pngPath = Path.Combine(tempDir, "bg.png");
+        var tex = new Texture2D(1, 1);
+        tex.SetPixel(0, 0, Color.white);
+        tex.Apply();
+        File.WriteAllBytes(pngPath, tex.EncodeToPNG());
+
+        // Inject the directory into the manager's downloaded pack list.
+        typeof(UIManager).GetField("downloadedPacks", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(ui, new List<string> { tempDir });
+
+        // The method should apply the sprite without throwing and update the renderer.
+        Assert.DoesNotThrow(() => ui.ApplyFirstWorkshopItem());
+        Assert.IsNotNull(bgObj.GetComponent<SpriteRenderer>().sprite, "Workshop application should set the background sprite.");
+
+        // Clean up objects and temporary files.
+        Object.DestroyImmediate(uiObj);
+        Object.DestroyImmediate(bgObj);
+        Directory.Delete(tempDir, true);
+    }
+#endif
 }
 


### PR DESCRIPTION
## Summary
- cache ParallaxBackground on UIManager initialization to avoid repeated searches
- reuse cached background when applying workshop packs
- test parallax background caching and workshop application logic

## Testing
- `npm test`
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*