### PR TITLE
feat: track pooled instance count

### DIFF
--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -19,6 +19,10 @@ using System.Collections.Generic;
  *   emit warnings when expansion is requested beyond the cap.
  * - Replaced Start's synchronous preloading loop with an asynchronous coroutine
  *   that spreads instantiation across multiple frames to avoid hitches.
+ * - Added a private counter tracking the number of pooled instances. The
+ *   counter replaces reliance on <c>transform.childCount</c> so only objects
+ *   created by this pool contribute toward <see cref="maxSize"/> and is
+ *   decremented when an instance is destroyed.
  */
 
 /// <summary>
@@ -63,6 +67,25 @@ public class ObjectPool : MonoBehaviour
     public int maxSize = 0;
 
     private Queue<PooledObject> objects = new Queue<PooledObject>();
+
+    /// <summary>
+    /// Tracks how many objects this pool has created that still exist.
+    /// <para>
+    /// Using a dedicated counter instead of relying on
+    /// <c>transform.childCount</c> ensures that only legitimate pooled
+    /// instances are considered when enforcing <see cref="maxSize"/>,
+    /// avoiding interference from unrelated children under the pool's
+    /// transform.
+    /// </para>
+    /// </summary>
+    private int pooledInstanceCount = 0;
+
+    /// <summary>
+    /// Read-only access for tests and diagnostics to see how many pooled
+    /// instances currently exist. External systems should not modify the
+    /// counter directly.
+    /// </summary>
+    public int PooledInstanceCount => pooledInstanceCount;
 
     // Delay initialization until Start so prefab can be assigned by spawners
     // before the pool creates its initial objects.
@@ -129,10 +152,11 @@ public class ObjectPool : MonoBehaviour
     /// </summary>
     PooledObject CreateNew()
     {
-        // Enforce the optional maxSize limit to prevent runaway growth. When
-        // the limit is reached, log a warning and refuse to create more
-        // instances so callers can react appropriately.
-        if (maxSize > 0 && transform.childCount >= maxSize)
+        // Enforce the optional maxSize limit using the dedicated counter so
+        // only objects created by this pool contribute to the limit. This
+        // avoids issues where unrelated children under the transform would
+        // otherwise block expansion.
+        if (maxSize > 0 && pooledInstanceCount >= maxSize)
         {
             Debug.LogWarning($"{nameof(ObjectPool)} on {name} cannot expand beyond max size of {maxSize}.");
             return null;
@@ -142,6 +166,11 @@ public class ObjectPool : MonoBehaviour
         // hierarchy stays clean in the editor.
         GameObject obj = Instantiate(prefab, transform);
         obj.SetActive(false);
+
+        // Update our internal counter now that a new pooled object exists. The
+        // decrement occurs in <see cref="OnPooledObjectDestroyed"/> when the
+        // instance is destroyed.
+        pooledInstanceCount++;
 
         // Check if the instantiated object already contains a PooledObject
         // component. Prefabs can define it ahead of time to perform custom
@@ -230,6 +259,39 @@ public class ObjectPool : MonoBehaviour
             // the pool's internal state consistent and free of foreign entries.
             Debug.LogWarning($"{nameof(ObjectPool)} on {name} received an object that does not belong to this pool; destroying to maintain integrity.");
             Destroy(obj);
+        }
+    }
+
+    /// <summary>
+    /// Called by <see cref="PooledObject"/> when a pooled instance is
+    /// destroyed instead of returned. This keeps the internal counter
+    /// accurate so the pool can spawn replacements if needed.
+    /// </summary>
+    /// <param name="po">The pooled object being destroyed.</param>
+    internal void OnPooledObjectDestroyed(PooledObject po)
+    {
+        // Reduce the count but ensure it never drops below zero in case the
+        // notification is sent unexpectedly.
+        if (pooledInstanceCount > 0)
+        {
+            pooledInstanceCount--;
+        }
+
+        // Remove the object from the queue if it was waiting there to avoid
+        // stale references. Create a new queue to filter out the destroyed
+        // instance while preserving ordering.
+        if (objects.Contains(po))
+        {
+            var remaining = new Queue<PooledObject>(objects.Count);
+            while (objects.Count > 0)
+            {
+                var item = objects.Dequeue();
+                if (item != po)
+                {
+                    remaining.Enqueue(item);
+                }
+            }
+            objects = remaining;
         }
     }
 }

--- a/Assets/Scripts/PooledObject.cs
+++ b/Assets/Scripts/PooledObject.cs
@@ -4,6 +4,13 @@ using UnityEngine;
 /// Simple component used by <see cref="ObjectPool"/> to mark an instance
 /// as belonging to a particular pool. Objects with this component are
 /// returned to the pool instead of being destroyed.
+///
+/// <para>
+/// In addition to tracking ownership, the component notifies its pool when
+/// the GameObject is destroyed. This keeps the pool's internal instance
+/// counter accurate even if clients destroy objects manually instead of
+/// returning them.
+/// </para>
 /// </summary>
 public class PooledObject : MonoBehaviour
 {
@@ -13,4 +20,17 @@ public class PooledObject : MonoBehaviour
     /// belongs to. Assigned automatically when created.
     /// </summary>
     public ObjectPool Pool;
+
+    /// <summary>
+    /// When the object is destroyed directly rather than returned to the
+    /// pool, inform the pool so it can decrement its internal counter and
+    /// clean up any queued references.
+    /// </summary>
+    void OnDestroy()
+    {
+        // The Pool reference may be null if the component is placed in the
+        // scene independently of a pool. The null-conditional operator
+        // prevents a null reference exception in such cases.
+        Pool?.OnPooledObjectDestroyed(this);
+    }
 }

--- a/Assets/Tests/EditMode/ObjectPoolEdgeTests.cs
+++ b/Assets/Tests/EditMode/ObjectPoolEdgeTests.cs
@@ -32,7 +32,7 @@ public class ObjectPoolEdgeTests
         var second = pool.GetObject(Vector3.one, Quaternion.identity);
 
         // Two children under the pool indicates it expanded.
-        Assert.AreEqual(2, pool.transform.childCount,
+        Assert.AreEqual(2, pool.PooledInstanceCount,
             "Pool should instantiate a new object when empty");
 
         Object.DestroyImmediate(first);
@@ -153,6 +153,69 @@ public class ObjectPoolEdgeTests
             "Prefab-defined PooledObject should be reused, not duplicated");
 
         Object.DestroyImmediate(obj);
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(poolGO);
+    }
+
+    /// <summary>
+    /// Ensures that unrelated children under the pool's transform do not
+    /// contribute to <see cref="ObjectPool.maxSize"/>. Only objects created by
+    /// the pool should affect the cap, allowing designers to organise helper
+    /// objects under the pool without blocking instantiation.
+    /// </summary>
+    [Test]
+    public void MaxSize_IgnoresNonPooledChildren()
+    {
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+        pool.maxSize = 1;
+
+        // Add an unrelated child object to simulate design-time helpers or
+        // markers that should not count toward pooled instance limits.
+        var helper = new GameObject("helper");
+        helper.transform.SetParent(poolGO.transform);
+
+        // Request an object; despite the extra child the pool should still
+        // instantiate because only pooled objects are counted.
+        var obj = pool.GetObject(Vector3.zero, Quaternion.identity);
+        Assert.IsNotNull(obj, "Pooled object should be created even with foreign children present");
+
+        Object.DestroyImmediate(obj);
+        Object.DestroyImmediate(helper);
+        Object.DestroyImmediate(pool.prefab);
+        Object.DestroyImmediate(poolGO);
+    }
+
+    /// <summary>
+    /// Verifies that destroying a pooled instance outside of
+    /// <see cref="ObjectPool.ReturnObject"/> properly decrements the internal
+    /// counter so the pool can create replacements when under its
+    /// <see cref="ObjectPool.maxSize"/> limit.
+    /// </summary>
+    [Test]
+    public void DestroyedInstance_DecrementsCounter()
+    {
+        var poolGO = new GameObject("pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        pool.prefab = new GameObject("prefab");
+        pool.maxSize = 1;
+
+        // Create and immediately destroy an instance to simulate external
+        // destruction without returning to the pool.
+        var obj = pool.GetObject(Vector3.zero, Quaternion.identity);
+        Object.DestroyImmediate(obj);
+
+        // The counter should reflect that no pooled instances remain.
+        Assert.AreEqual(0, pool.PooledInstanceCount,
+            "Counter must decrement when pooled instance is destroyed");
+
+        // With the count reduced, requesting another object should succeed.
+        var replacement = pool.GetObject(Vector3.zero, Quaternion.identity);
+        Assert.IsNotNull(replacement,
+            "Pool should spawn replacement after destruction frees slot");
+
+        Object.DestroyImmediate(replacement);
         Object.DestroyImmediate(pool.prefab);
         Object.DestroyImmediate(poolGO);
     }

--- a/Assets/Tests/EditMode/ObjectPoolTests.cs
+++ b/Assets/Tests/EditMode/ObjectPoolTests.cs
@@ -86,12 +86,12 @@ public class ObjectPoolTests
 
         // Immediately after Start only the first object should exist because
         // the coroutine yields after each instantiation.
-        Assert.AreEqual(1, pool.transform.childCount,
+        Assert.AreEqual(1, pool.PooledInstanceCount,
             "First preload iteration should run immediately");
 
         // Allow one frame for the coroutine to continue and create the second object.
         yield return null;
-        Assert.AreEqual(2, pool.transform.childCount,
+        Assert.AreEqual(2, pool.PooledInstanceCount,
             "Second preload iteration should occur on following frame");
 
         Object.DestroyImmediate(pool.prefab);


### PR DESCRIPTION
## Summary
- track pooled instance count instead of using transform.childCount
- decrement count when pooled instances are destroyed
- cover pooled instance counting edge cases in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6280112008321a2df5c4284f5a8e0