### PR TITLE
feat: async save game loading

### DIFF
--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -27,6 +27,10 @@
 // 2032 update: Introduced a dirty flag and autosave coroutine so frequent
 // property updates are batched. Data writes now occur at most once every few
 // seconds, significantly reducing disk churn during gameplay.
+// 2033 update: LoadData now performs asynchronous reads via
+// File.ReadAllTextAsync and Awake triggers loading without blocking. A Start
+// coroutine awaits completion so startup remains responsive while still
+// ensuring the manager is fully initialized before use.
 // -----------------------------------------------------------------------------
 
 using System;
@@ -36,6 +40,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections;
 using UnityEngine;
 
 /// <summary>
@@ -60,7 +65,7 @@ public class SaveGameManager : MonoBehaviour
     private class SaveData
     {
         // Bump <see cref="CurrentVersion"/> when fields are added so older
-        // saves can be upgraded in <see cref="LoadData"/>.
+        // saves can be upgraded in <see cref="LoadDataAsync"/>.
         public int version;
         public int coins;
         public int highScore;
@@ -84,6 +89,18 @@ public class SaveGameManager : MonoBehaviour
     private SaveData data = new SaveData();
     private readonly Dictionary<UpgradeType, int> upgradeLevels = new Dictionary<UpgradeType, int>();
     private string savePath;
+
+    // Task representing the asynchronous load of persisted data. This allows
+    // callers and tests to await initialization without blocking the main
+    // Unity thread during startup.
+    private Task loadTask = Task.CompletedTask;
+
+    /// <summary>
+    /// Exposes the task for the most recent load operation so external code
+    /// can await completion and be sure the manager's data has been populated
+    /// before it is accessed.
+    /// </summary>
+    public Task Initialization => loadTask;
 
     // Data packet used for queued save operations. Each request stores both the
     // serialized JSON payload and the path it should be written to so that
@@ -140,7 +157,10 @@ public class SaveGameManager : MonoBehaviour
             DontDestroyOnLoad(gameObject);
             // Use the SaveSlotManager so each profile writes to its own file
             savePath = SaveSlotManager.GetPath("savegame.json");
-            LoadData();
+            // Begin loading asynchronously so the main thread remains
+            // responsive during startup. The resulting task is exposed via
+            // <see cref="Initialization"/> so callers can await completion.
+            loadTask = LoadDataAsync();
             // Initialize save timestamp so the first autosave waits the
             // configured interval rather than firing immediately.
             lastSaveTime = Time.realtimeSinceStartup;
@@ -152,6 +172,17 @@ public class SaveGameManager : MonoBehaviour
         {
             Destroy(gameObject);
         }
+    }
+
+    /// <summary>
+    /// Unity coroutine automatically invoked after <see cref="Awake"/>. It
+    /// waits for the asynchronous load started during Awake to finish without
+    /// blocking the main thread. This ensures the manager's data is fully
+    /// populated before other systems rely on it.
+    /// </summary>
+    private IEnumerator Start()
+    {
+        yield return new WaitUntil(() => loadTask.IsCompleted);
     }
 
     /// <summary>Current coin balance.</summary>
@@ -376,13 +407,15 @@ public class SaveGameManager : MonoBehaviour
     /// Reads existing save data from disk or migrates old PlayerPrefs data when
     /// the save file does not yet exist.
     /// </summary>
-    private void LoadData()
+    private async Task LoadDataAsync()
     {
         if (File.Exists(savePath))
         {
             try
             {
-                string json = File.ReadAllText(savePath);
+                // Asynchronously read the entire save file so disk IO does not
+                // stall the main thread during startup.
+                string json = await File.ReadAllTextAsync(savePath);
                 SaveData loaded = JsonUtility.FromJson<SaveData>(json);
                 if (loaded != null)
                 {
@@ -417,7 +450,7 @@ public class SaveGameManager : MonoBehaviour
                     data.slideTipShown = loaded.slideTipShown;
                     data.hardcoreMode = loaded.hardcoreMode;
                     LocalizationManager.SetLanguage(data.language);
-                    
+
                     upgradeLevels.Clear();
                     if (loaded.upgrades != null)
                     {
@@ -704,9 +737,12 @@ public class SaveGameManager : MonoBehaviour
         // callers to await rather than stall the main thread.
         await FlushPendingSavesAsync(Timeout.InfiniteTimeSpan);
 
-        // Redirect file paths to the new slot and load its data.
+        // Redirect file paths to the new slot and load its data asynchronously
+        // so the main thread remains responsive during the potentially slow
+        // disk read.
         SaveSlotManager.SetSlot(slot);
         savePath = SaveSlotManager.GetPath("savegame.json");
-        LoadData();
+        loadTask = LoadDataAsync();
+        await loadTask;
     }
 }

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -32,6 +32,20 @@ public class SaveGameManagerTests
     }
 
     /// <summary>
+    /// Creates a <see cref="SaveGameManager"/> or subclass and blocks until its
+    /// asynchronous initialization has completed. Tests rely on this helper so
+    /// they operate on fully loaded data despite the production code loading
+    /// in the background.
+    /// </summary>
+    private static T CreateManager<T>(string name) where T : SaveGameManager
+    {
+        var go = new GameObject(name);
+        var mgr = go.AddComponent<T>();
+        mgr.Initialization.GetAwaiter().GetResult();
+        return mgr;
+    }
+
+    /// <summary>
     /// Flushes any pending asynchronous save operation for the provided manager
     /// and destroys its GameObject. Tests use this helper to ensure data reaches
     /// disk before a new <see cref="SaveGameManager"/> is instantiated.
@@ -47,8 +61,7 @@ public class SaveGameManagerTests
     [Test]
     public void SaveAndLoad_PersistsData()
     {
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
         save.Coins = 7;
         save.HighScore = 12;
         save.SetUpgradeLevel(UpgradeType.MagnetDuration, 2);
@@ -56,8 +69,7 @@ public class SaveGameManagerTests
         FlushAndDestroy(save);
 
         // Create a new instance which should load from the file
-        var go2 = new GameObject("save2");
-        var save2 = go2.AddComponent<SaveGameManager>();
+        var save2 = CreateManager<SaveGameManager>("save2");
 
         Assert.AreEqual(7, save2.Coins);
         Assert.AreEqual(12, save2.HighScore);
@@ -74,8 +86,7 @@ public class SaveGameManagerTests
         PlayerPrefs.SetInt("UpgradeLevel_MagnetDuration", 1);
         PlayerPrefs.Save();
 
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
 
         Assert.AreEqual(3, save.Coins);
         Assert.AreEqual(4, save.HighScore);
@@ -89,8 +100,7 @@ public class SaveGameManagerTests
     public void Save_UsesTemporaryFile()
     {
         // Saving should not leave the temporary file used for atomic writes.
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
 
         save.Coins = 1; // triggers SaveDataToFile
 
@@ -104,14 +114,12 @@ public class SaveGameManagerTests
     [Test]
     public void VolumeValues_ArePersisted()
     {
-        var obj = new GameObject("save");
-        var save = obj.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
         save.MusicVolume = 0.4f;
         save.EffectsVolume = 0.7f;
         FlushAndDestroy(save);
 
-        var obj2 = new GameObject("save2");
-        var save2 = obj2.AddComponent<SaveGameManager>();
+        var save2 = CreateManager<SaveGameManager>("save2");
         Assert.AreEqual(0.4f, save2.MusicVolume, 0.001f);
         Assert.AreEqual(0.7f, save2.EffectsVolume, 0.001f);
         FlushAndDestroy(save2);
@@ -124,8 +132,7 @@ public class SaveGameManagerTests
         string path = Path.Combine(Application.persistentDataPath, "savegame.json");
         File.WriteAllText(path, "{\"coins\":1,\"highScore\":2,\"upgrades\":[]}");
 
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
 
         Assert.AreEqual(1f, save.MusicVolume);
         Assert.AreEqual(1f, save.EffectsVolume);
@@ -135,8 +142,7 @@ public class SaveGameManagerTests
     [Test]
     public void VersionField_WrittenToFile()
     {
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
         FlushAndDestroy(save);
 
         string path = Path.Combine(Application.persistentDataPath, "savegame.json");
@@ -148,13 +154,11 @@ public class SaveGameManagerTests
     public void LanguageValue_IsPersisted()
     {
         // Save a language preference and ensure it loads correctly on next startup
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
         save.Language = "es";
         FlushAndDestroy(save);
 
-        var go2 = new GameObject("save2");
-        var save2 = go2.AddComponent<SaveGameManager>();
+        var save2 = CreateManager<SaveGameManager>("save2");
         Assert.AreEqual("es", save2.Language);
         FlushAndDestroy(save2);
     }
@@ -167,8 +171,7 @@ public class SaveGameManagerTests
         string path = Path.Combine(Application.persistentDataPath, "savegame.json");
         File.WriteAllText(path, "{\"coins\":2,\"highScore\":3}");
 
-        var go = new GameObject("save");
-        var save = go.AddComponent<SaveGameManager>();
+        var save = CreateManager<SaveGameManager>("save");
 
         Assert.AreEqual(2, save.Coins);
         Assert.AreEqual(3, save.HighScore);
@@ -183,15 +186,13 @@ public class SaveGameManagerTests
         // Write data to the initial slot then change to a new slot and verify
         // values persist separately.
         SaveSlotManager.SetSlot(0);
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SaveGameManager>();
+        var mgr = CreateManager<SaveGameManager>("save");
         mgr.Coins = 2;
         await mgr.ChangeSlot(1);
         mgr.Coins = 5;
         FlushAndDestroy(mgr);
 
-        var obj2 = new GameObject("save2");
-        var mgr2 = obj2.AddComponent<SaveGameManager>();
+        var mgr2 = CreateManager<SaveGameManager>("save2");
         Assert.AreEqual(5, mgr2.Coins, "Slot 1 should contain updated value");
         await mgr2.ChangeSlot(0);
         Assert.AreEqual(2, mgr2.Coins, "Slot 0 should retain original value");
@@ -208,8 +209,7 @@ public class SaveGameManagerTests
     {
         // Begin in slot 0 and queue a save that will complete slowly.
         SaveSlotManager.SetSlot(0);
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SlowSaveGameManager>();
+        var mgr = CreateManager<SlowSaveGameManager>("save");
         mgr.Coins = 1; // queue save for slot 0
 
         // Immediately switch to slot 1. ChangeSlot should block until the first
@@ -220,14 +220,12 @@ public class SaveGameManagerTests
 
         // Verify slot 0 contains the first value and slot 1 the second.
         SaveSlotManager.SetSlot(0);
-        var check0 = new GameObject("check0");
-        var mgr0 = check0.AddComponent<SaveGameManager>();
+        var mgr0 = CreateManager<SaveGameManager>("check0");
         Assert.AreEqual(1, mgr0.Coins, "Slot 0 should persist initial value");
         FlushAndDestroy(mgr0);
 
         SaveSlotManager.SetSlot(1);
-        var check1 = new GameObject("check1");
-        var mgr1 = check1.AddComponent<SaveGameManager>();
+        var mgr1 = CreateManager<SaveGameManager>("check1");
         Assert.AreEqual(2, mgr1.Coins, "Slot 1 should contain updated value");
         FlushAndDestroy(mgr1);
     }
@@ -239,8 +237,7 @@ public class SaveGameManagerTests
     [Test]
     public void SaveDataToFile_InvalidPath_LogsWarning()
     {
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SaveGameManager>();
+        var mgr = CreateManager<SaveGameManager>("save");
 
         FieldInfo pathField = typeof(SaveGameManager).GetField("savePath", BindingFlags.NonPublic | BindingFlags.Instance);
         pathField.SetValue(mgr, Path.Combine(Application.dataPath, "no_such_dir", "save.json"));
@@ -270,8 +267,7 @@ public class SaveGameManagerTests
         File.WriteAllText(path, "{ invalid json }");
 
         // Loading should detect the bad file and regenerate a default save.
-        var go = new GameObject("save");
-        var mgr = go.AddComponent<SaveGameManager>();
+        var mgr = CreateManager<SaveGameManager>("save");
 
         // All persistent values should revert to their defaults.
         Assert.AreEqual(0, mgr.Coins, "Coins should reset when save is invalid");
@@ -316,8 +312,7 @@ public class SaveGameManagerTests
     [UnityTest]
     public IEnumerator UpdateUpgradeLevels_BatchesWrites()
     {
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SaveGameManagerSpy>();
+        var mgr = CreateManager<SaveGameManagerSpy>("save");
 
         var dict1 = new Dictionary<UpgradeType, int>
         {
@@ -349,8 +344,7 @@ public class SaveGameManagerTests
     [UnityTest]
     public IEnumerator PropertySetters_TriggerDelayedSave()
     {
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SaveGameManagerSpy>();
+        var mgr = CreateManager<SaveGameManagerSpy>("save");
 
         mgr.Coins = 5; // mark data dirty
 
@@ -372,8 +366,7 @@ public class SaveGameManagerTests
     [Test]
     public void SlowDisk_DoesNotBlockMainThread()
     {
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SlowSaveGameManager>();
+        var mgr = CreateManager<SlowSaveGameManager>("save");
 
         var timer = Stopwatch.StartNew();
         mgr.Coins = 3; // triggers asynchronous save
@@ -391,8 +384,7 @@ public class SaveGameManagerTests
     [Test]
     public void QuitHandler_FlushesWithoutBlocking()
     {
-        var obj = new GameObject("save");
-        var mgr = obj.AddComponent<SlowSaveGameManager>();
+        var mgr = CreateManager<SlowSaveGameManager>("save");
         mgr.Coins = 9; // queue save
 
         // Reflectively invoke the private handler used by Application.quitting.
@@ -405,8 +397,7 @@ public class SaveGameManagerTests
         // Allow the asynchronous save to finish so data reaches disk.
         Task.Delay(300).Wait();
 
-        var obj2 = new GameObject("check");
-        var mgr2 = obj2.AddComponent<SaveGameManager>();
+        var mgr2 = CreateManager<SaveGameManager>("check");
         Assert.AreEqual(9, mgr2.Coins, "Data should persist after quit handler");
 
         FlushAndDestroy(mgr2);


### PR DESCRIPTION
## Summary
- load save file asynchronously for responsive startup
- expose initialization task and wait in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73af2cb088321a655935cd71833af