### PR TITLE
Harden save slot path handling

### DIFF
--- a/Assets/Scripts/SaveSlotManager.cs
+++ b/Assets/Scripts/SaveSlotManager.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 // stored. Each slot corresponds to its own directory under the application's
 // persistent data path. The active slot index is persisted using PlayerPrefs so
 // profiles remain consistent across sessions.
+//
+// 2026 update: Added defensive file name validation and robust directory
+// creation with logging so malformed inputs and filesystem issues gracefully
+// fall back to a safe location instead of crashing.
 // -----------------------------------------------------------------------------
 /// <summary>
 /// Manages the currently selected save slot. Each slot stores game data in a
@@ -50,17 +54,56 @@ public static class SaveSlotManager
 
     /// <summary>
     /// Returns a path inside the current slot's directory for the given file
-    /// name. The directory is created if it does not already exist. Callers are
-    /// expected to provide only a file name, not a full or relative path.
+    /// name. The directory is created if it does not already exist. Callers must
+    /// provide only a simple file name; any path segments are rejected to avoid
+    /// traversal attacks. If the slot directory cannot be created due to an
+    /// <see cref="IOException"/> or <see cref="UnauthorizedAccessException"/>, the
+    /// method logs the failure and falls back to <see
+    /// cref="Application.persistentDataPath"/>.
     /// </summary>
+    /// <param name="fileName">Name of the file to locate inside the current save slot.</param>
+    /// <returns>Full path to the requested file within the slot or a fallback path on error.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fileName"/> is null, empty, or contains path separators.</exception>
     public static string GetPath(string fileName)
     {
-        string dir = Path.Combine(Application.persistentDataPath, $"slot_{CurrentSlot}");
-        if (!Directory.Exists(dir))
+        // Validate input to ensure callers cannot escape the save directory or
+        // create unexpected files. Path.GetFileName strips directories; if it
+        // alters the provided string then a path segment was present.
+        if (string.IsNullOrWhiteSpace(fileName) || Path.GetFileName(fileName) != fileName)
         {
-            Directory.CreateDirectory(dir);
+            throw new ArgumentException("File name must be a non-empty simple name", nameof(fileName));
         }
-        return Path.Combine(dir, fileName);
+
+        // Compute the directory for the active slot. Each slot isolates its
+        // data under a unique folder so multiple profiles remain separated.
+        string dir = Path.Combine(Application.persistentDataPath, $"slot_{CurrentSlot}");
+
+        try
+        {
+            // Lazily create the directory when first accessed. Directory.Exists
+            // returns false when a file occupies the path, which will trigger an
+            // exception in CreateDirectory that we handle below.
+            if (!Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            // Join the sanitized file name to the slot directory path.
+            return Path.Combine(dir, fileName);
+        }
+        catch (IOException ex)
+        {
+            // Log and fall back to the root persistent path so saving can still
+            // proceed in a predictable location.
+            LoggingHelper.LogError($"Failed to create save slot directory '{dir}': {ex.Message}");
+            return Path.Combine(Application.persistentDataPath, fileName);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // Permissions issues are treated similarly to IO failures.
+            LoggingHelper.LogError($"Failed to create save slot directory '{dir}': {ex.Message}");
+            return Path.Combine(Application.persistentDataPath, fileName);
+        }
     }
 }
 

--- a/Assets/Tests/EditMode/SaveSlotManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveSlotManagerTests.cs
@@ -1,0 +1,75 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Unit tests for <see cref="SaveSlotManager"/> verifying file name validation,
+/// directory creation behaviour, and fallback logic when the slot directory
+/// cannot be created.
+/// </summary>
+public class SaveSlotManagerTests
+{
+    [SetUp]
+    public void CleanUp()
+    {
+        // Reset persistent data and PlayerPrefs to avoid test cross-contamination.
+        PlayerPrefs.DeleteAll();
+        for (int i = 0; i < SaveSlotManager.MaxSlots; i++)
+        {
+            string dir = Path.Combine(Application.persistentDataPath, $"slot_{i}");
+            if (File.Exists(dir))
+            {
+                // If a file exists where a directory should be, remove it.
+                File.Delete(dir);
+            }
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Test]
+    public void GetPath_ValidFileName_ReturnsSlotPath()
+    {
+        // The returned path should include the slot directory when provided a
+        // simple file name.
+        string result = SaveSlotManager.GetPath("save.json");
+        string expected = Path.Combine(Application.persistentDataPath,
+            $"slot_{SaveSlotManager.CurrentSlot}", "save.json");
+        Assert.AreEqual(expected, result);
+    }
+
+    [Test]
+    public void GetPath_InvalidFileName_Throws()
+    {
+        // Path segments should be rejected to avoid traversal attacks.
+        Assert.Throws<ArgumentException>(() => SaveSlotManager.GetPath("../save.json"));
+        // Empty or whitespace names are similarly invalid.
+        Assert.Throws<ArgumentException>(() => SaveSlotManager.GetPath("   "));
+    }
+
+    [Test]
+    public void GetPath_DirectoryCreationFails_ReturnsFallback()
+    {
+        // Create a file where the slot directory should be so CreateDirectory
+        // throws an IOException, forcing the method to fall back.
+        string slotPath = Path.Combine(Application.persistentDataPath,
+            $"slot_{SaveSlotManager.CurrentSlot}");
+        File.WriteAllText(slotPath, "dummy");
+
+        try
+        {
+            string result = SaveSlotManager.GetPath("save.json");
+            // Without a directory the fallback should be the root persistent path.
+            string expected = Path.Combine(Application.persistentDataPath, "save.json");
+            Assert.AreEqual(expected, result);
+        }
+        finally
+        {
+            // Ensure the temporary file is removed even if the assertion fails.
+            File.Delete(slotPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate save file names to reject empty and path-traversal inputs
- handle directory creation failures with LoggingHelper and fallback path
- cover save-slot path logic with unit tests

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*