### PR TITLE
Validate GameManager dependencies and add null-safe operations

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -73,6 +73,12 @@ using System.Collections;
 /// build configurations can suppress verbose output while still surfacing
 /// critical issues.
 /// </remarks>
+/// <remarks>
+/// 2042 update: adds explicit dependency validation in <see cref="Awake"/> and
+/// replaces direct property access in <see cref="GameOver"/> and
+/// <see cref="StartGame"/> with null-safe handling to prevent runtime
+/// exceptions when supporting managers or UI elements are missing.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -238,6 +244,41 @@ public class GameManager : MonoBehaviour
             return;
         }
 
+        // Validate critical dependencies before proceeding. Missing references
+        // indicate a misconfigured scene and could lead to null reference
+        // exceptions later in initialization. Logging an explicit error helps
+        // developers quickly diagnose the issue.
+        bool missingDependencies = false;
+        if (SaveGameManager.Instance == null)
+        {
+            LoggingHelper.LogError("Awake: SaveGameManager instance not found. Aborting initialization.");
+            missingDependencies = true;
+        }
+        if (scoreLabel == null)
+        {
+            LoggingHelper.LogError("Awake: scoreLabel reference not set.");
+            missingDependencies = true;
+        }
+        if (highScoreLabel == null)
+        {
+            LoggingHelper.LogError("Awake: highScoreLabel reference not set.");
+            missingDependencies = true;
+        }
+        if (coinLabel == null)
+        {
+            LoggingHelper.LogError("Awake: coinLabel reference not set.");
+            missingDependencies = true;
+        }
+        if (comboLabel == null)
+        {
+            LoggingHelper.LogError("Awake: comboLabel reference not set.");
+            missingDependencies = true;
+        }
+        if (missingDependencies)
+        {
+            return; // Abort setup when essential components are missing
+        }
+
         // Load the persisted hardcore mode preference after ensuring
         // SaveGameManager exists. Default to false when no save is present.
         hardcoreMode = SaveGameManager.Instance != null && SaveGameManager.Instance.HardcoreMode;
@@ -394,14 +435,31 @@ public class GameManager : MonoBehaviour
         }
         coinBonusMultiplier = 1f;
         coinBonusTimer = 0f;
+
         int finalScore = Mathf.FloorToInt(distance);
-        int highScore = SaveGameManager.Instance.HighScore;
+
+        // Use null-conditional access so a missing save system does not crash
+        // the game. Fallback to zero when no high score is available.
+        var save = SaveGameManager.Instance;
+        int highScore = save?.HighScore ?? 0;
+        if (save == null)
+        {
+            LoggingHelper.LogError("GameOver: SaveGameManager missing; using default high score of 0.");
+        }
 
         // Persist a new high score locally and to Steam if available
         if (finalScore > highScore)
         {
             highScore = finalScore;
-            SaveGameManager.Instance.HighScore = highScore;
+            if (save != null)
+            {
+                // Persist the new high score when a save system exists.
+                save.HighScore = highScore;
+            }
+            else
+            {
+                LoggingHelper.LogError("GameOver: SaveGameManager missing; high score not saved.");
+            }
             if (SteamManager.Instance != null)
             {
                 SteamManager.Instance.SaveHighScore(highScore);
@@ -445,9 +503,14 @@ public class GameManager : MonoBehaviour
         }
 
         // Persist run coins so they can be spent in the shop
-        if (ShopManager.Instance != null)
+        var shop = ShopManager.Instance;
+        if (shop != null)
         {
-            ShopManager.Instance.AddCoins(coins);
+            shop.AddCoins(coins);
+        }
+        else
+        {
+            LoggingHelper.LogError("GameOver: ShopManager missing; coins not persisted.");
         }
         // Update the UI with the final results
         if (uiManager != null)
@@ -459,7 +522,15 @@ public class GameManager : MonoBehaviour
         {
             AnalyticsManager.Instance.LogRun(distance, coins, true);
         }
-        UpdateHighScoreLabel();
+        // Update the high score label only when the save system exists.
+        if (SaveGameManager.Instance != null)
+        {
+            UpdateHighScoreLabel();
+        }
+        else
+        {
+            LoggingHelper.LogError("GameOver: SaveGameManager missing; high score label not updated.");
+        }
     }
 
     /// <summary>
@@ -488,10 +559,15 @@ public class GameManager : MonoBehaviour
         isPaused = false;
         isGameOver = false;
         distance = 0f;
-        float bonus = 0f;
-        if (ShopManager.Instance != null)
+
+        // Query the shop for upgrades using null-conditional access. When the
+        // shop is missing, default values are used and an error is logged so
+        // developers understand why bonuses were skipped.
+        var shop = ShopManager.Instance;
+        float bonus = shop?.GetUpgradeEffect(UpgradeType.BaseSpeedBonus) ?? 0f;
+        if (shop == null)
         {
-            bonus = ShopManager.Instance.GetUpgradeEffect(UpgradeType.BaseSpeedBonus);
+            LoggingHelper.LogError("StartGame: ShopManager missing; using base speed without bonuses.");
         }
         currentSpeed = baseSpeed + bonus;
         coins = 0;
@@ -510,10 +586,10 @@ public class GameManager : MonoBehaviour
         Time.timeScale = 1f;
 
         // Validate required references and spawn starting power-ups if configured.
-        int startingCount = 0;
-        if (ShopManager.Instance != null)
+        int startingCount = Mathf.RoundToInt(shop?.GetUpgradeEffect(UpgradeType.StartingPowerUp) ?? 0f);
+        if (shop == null)
         {
-            startingCount = Mathf.RoundToInt(ShopManager.Instance.GetUpgradeEffect(UpgradeType.StartingPowerUp));
+            LoggingHelper.LogError("StartGame: ShopManager missing; starting power-ups unavailable.");
         }
 
         // Ensure the player reference exists so dependent logic operates safely.

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.UI;               // Needed for assigning UI Text references
 using System;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -21,12 +22,43 @@ using System.Text.RegularExpressions;
 
 public class GameManagerTests
 {
+    /// <summary>
+    /// Creates a <see cref="GameManager"/> (or subclass) with the required UI
+    /// label references. Parenting the labels to the manager ensures they clean
+    /// up automatically when the manager is destroyed.
+    /// </summary>
+    private T CreateGameManagerWithUI<T>() where T : GameManager
+    {
+        var go = new GameObject("gm");
+        var gm = go.AddComponent<T>();
+
+        gm.scoreLabel = new GameObject("scoreLabel").AddComponent<Text>();
+        gm.scoreLabel.transform.SetParent(go.transform);
+
+        gm.highScoreLabel = new GameObject("highScoreLabel").AddComponent<Text>();
+        gm.highScoreLabel.transform.SetParent(go.transform);
+
+        gm.coinLabel = new GameObject("coinLabel").AddComponent<Text>();
+        gm.coinLabel.transform.SetParent(go.transform);
+
+        gm.comboLabel = new GameObject("comboLabel").AddComponent<Text>();
+        gm.comboLabel.transform.SetParent(go.transform);
+
+        return gm;
+    }
+
+    // Convenience overload for tests that use the base GameManager type
+    private GameManager CreateGameManagerWithUI()
+    {
+        return CreateGameManagerWithUI<GameManager>();
+    }
+
     [Test]
     public void AddCoins_IncreasesTotal()
     {
-        // Create a temporary GameManager instance
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        // Create a temporary GameManager instance with required UI labels
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         gm.AddCoins(2);
         gm.AddCoins(3);
@@ -40,8 +72,8 @@ public class GameManagerTests
     public void ActivateSpeedBoost_MultipliesSpeed()
     {
         // GameManager must be running for speed boosts to apply
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Assign a dummy player reference to satisfy GameManager's runtime validation.
         var player = new GameObject("player");
@@ -65,8 +97,8 @@ public class GameManagerTests
     [Test]
     public void ActivateSpeedBoost_RejectsNonPositiveDuration()
     {
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Expect an ArgumentException when duration is zero.
         Assert.Throws<ArgumentException>(() => gm.ActivateSpeedBoost(0f, 1f));
@@ -80,8 +112,8 @@ public class GameManagerTests
     [Test]
     public void ActivateSpeedBoost_RejectsNonPositiveMultiplier()
     {
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Expect an ArgumentOutOfRangeException when multiplier is zero.
         Assert.Throws<ArgumentOutOfRangeException>(() => gm.ActivateSpeedBoost(1f, 0f));
@@ -92,8 +124,8 @@ public class GameManagerTests
     public void CoinCombo_IncrementsAndResets()
     {
         // Validate that coins picked up quickly increase the combo multiplier
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         gm.AddCoins(1);            // first coin, multiplier = 1
         gm.AddCoins(1);            // within combo window, multiplier now 2
@@ -122,8 +154,8 @@ public class GameManagerTests
     public void AddCoins_TriggersComboFeedback()
     {
         // Ensure OnComboIncreased is invoked when combo multiplier rises
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<TestGameManager>();
+        var gm = CreateGameManagerWithUI<TestGameManager>();
+        var go = gm.gameObject;
 
         gm.AddCoins(1);    // multiplier = 1
         gm.AddCoins(1);    // multiplier increments -> should trigger feedback
@@ -151,8 +183,8 @@ public class GameManagerTests
         levels[UpgradeType.CoinMultiplier] = 1;
         dictField.SetValue(sm, levels);
 
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         gm.AddCoins(1);
 
@@ -166,8 +198,8 @@ public class GameManagerTests
     [Test]
     public void ActivateCoinBonus_MultipliesCoins()
     {
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Provide the required player reference for StartGame.
         var player = new GameObject("player");
@@ -196,8 +228,8 @@ public class GameManagerTests
     [Test]
     public void ActivateCoinBonus_StacksDurationAndMultiplier()
     {
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Supply player reference so combo bonus logic can run safely.
         var player = new GameObject("player");
@@ -228,8 +260,8 @@ public class GameManagerTests
     [Test]
     public void GetCoinBonusMethods_ReturnCurrentValues()
     {
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Assign player reference for StartGame validation.
         var player = new GameObject("player");
@@ -250,8 +282,8 @@ public class GameManagerTests
     [Test]
     public void ActivateSlowMotion_ChangesTimeScale()
     {
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Create a dummy player object required by StartGame.
         var player = new GameObject("player");
@@ -284,8 +316,8 @@ public class GameManagerTests
         var saveObj = new GameObject("save");
         saveObj.AddComponent<SaveGameManager>();
 
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
 
         // Provide player reference so StartGame does not log errors.
         var player = new GameObject("player");
@@ -314,21 +346,19 @@ public class GameManagerTests
         // Enable hardcore mode and destroy the objects to force a save
         var saveObj = new GameObject("save");
         saveObj.AddComponent<SaveGameManager>();
-        var gmObj = new GameObject("gm");
-        var gm = gmObj.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
         gm.HardcoreMode = true;
-        Object.DestroyImmediate(gmObj);
+        Object.DestroyImmediate(gm.gameObject);
         Object.DestroyImmediate(saveObj);
 
         // Creating new instances should load the persisted setting
         var saveObj2 = new GameObject("save2");
         saveObj2.AddComponent<SaveGameManager>();
-        var gmObj2 = new GameObject("gm2");
-        var gm2 = gmObj2.AddComponent<GameManager>();
+        var gm2 = CreateGameManagerWithUI();
 
         Assert.IsTrue(gm2.HardcoreMode);
 
-        Object.DestroyImmediate(gmObj2);
+        Object.DestroyImmediate(gm2.gameObject);
         Object.DestroyImmediate(saveObj2);
     }
 
@@ -342,8 +372,8 @@ public class GameManagerTests
     public void Awake_DuplicateDoesNotReinitializeDependencies()
     {
         // Establish the primary manager which also spawns a SaveGameManager.
-        var primaryObj = new GameObject("gmPrimary");
-        primaryObj.AddComponent<GameManager>();
+        var primary = CreateGameManagerWithUI();
+        var primaryObj = primary.gameObject;
 
         // Simulate the supporting SaveGameManager being missing by destroying
         // it and clearing the static Instance field via reflection.
@@ -397,8 +427,8 @@ public class GameManagerTests
         dictField.SetValue(shop, levels);
 
         // GameManager with a simple power-up prefab to instantiate.
-        var go = new GameObject("gm");
-        var gm = go.AddComponent<GameManager>();
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
         gm.startingPowerUps = new[] { new GameObject("PowerUp") };
 
         // Expect an error about the missing player reference.
@@ -412,5 +442,71 @@ public class GameManagerTests
         Object.DestroyImmediate(go);
         Object.DestroyImmediate(shopObj);
         Object.DestroyImmediate(saveObj);
+    }
+
+    /// <summary>
+    /// Calling <see cref="GameManager.GameOver"/> with a missing save system
+    /// should log errors but still complete gracefully without throwing
+    /// exceptions.
+    /// </summary>
+    [Test]
+    public void GameOver_MissingSaveManager_LogsErrorAndUsesFallback()
+    {
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
+
+        // Provide a ShopManager to avoid unrelated error logs.
+        var shopObj = new GameObject("shop");
+        shopObj.AddComponent<ShopManager>();
+
+        // Remove the SaveGameManager instance to simulate a missing dependency.
+        if (SaveGameManager.Instance != null)
+        {
+            Object.DestroyImmediate(SaveGameManager.Instance.gameObject);
+            var instField = typeof(SaveGameManager).GetField("<Instance>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic);
+            instField.SetValue(null, null);
+        }
+
+        // Expect error logs about the missing save manager.
+        LogAssert.Expect(LogType.Error, new Regex("SaveGameManager missing"));
+        LogAssert.Expect(LogType.Error, new Regex("SaveGameManager missing"));
+        LogAssert.Expect(LogType.Error, new Regex("SaveGameManager missing"));
+
+        gm.GameOver();
+
+        LogAssert.NoUnexpectedReceived();
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(shopObj);
+    }
+
+    /// <summary>
+    /// <see cref="GameManager.StartGame"/> should use default values and log
+    /// errors when the <see cref="ShopManager"/> dependency is missing.
+    /// </summary>
+    [Test]
+    public void StartGame_MissingShopManager_UsesDefaultsAndLogsError()
+    {
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
+
+        // Supply required player reference so only ShopManager errors surface.
+        var player = new GameObject("player");
+        typeof(GameManager).GetField("playerObject", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, player);
+
+        // Expect two error logs: one for speed bonus and one for power-up count.
+        LogAssert.Expect(LogType.Error, new Regex("ShopManager missing"));
+        LogAssert.Expect(LogType.Error, new Regex("ShopManager missing"));
+
+        gm.StartGame();
+
+        // Without a shop, the starting speed should equal the base speed.
+        Assert.AreEqual(gm.baseSpeed, gm.GetSpeed());
+
+        LogAssert.NoUnexpectedReceived();
+
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(player);
     }
 }


### PR DESCRIPTION
## Summary
- Guard GameManager.Awake against missing SaveGameManager or UI labels and halt initialization when dependencies are absent
- Use null-conditional operators in GameOver and StartGame to safely interact with optional managers, logging when they are missing
- Expand tests with helpers and new cases covering missing SaveGameManager and ShopManager scenarios

## Testing
- `npm test`