### PR TITLE
Replace legacy Text with TMP_Text

### DIFF
--- a/Assets/Scripts/AchievementsMenu.cs
+++ b/Assets/Scripts/AchievementsMenu.cs
@@ -6,7 +6,7 @@
  * game runs without Steam (for example in WebGL) the menu will simply remain
  * empty. Typical usage:
  *   - Attach this component to a panel with a VerticalLayoutGroup.
- *   - Assign 'entryPrefab' which contains a Text component.
+ *   - Assign 'entryPrefab' which contains a TMP_Text component.
  *   - The Start method calls PopulateList automatically, but tests may invoke
  *     it directly.
  * Achievements are queried once at startup and displayed using localized
@@ -14,7 +14,7 @@
  * -----------------------------------------------------------------------------
  */
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro; // TextMeshPro is used for achievement entry labels
 #if UNITY_STANDALONE
 using Steamworks;
 #endif
@@ -22,15 +22,15 @@ using Steamworks;
 /// <summary>
 /// Displays a scrollable list of Steam achievements and their unlocked state.
 /// Attach this component to a panel containing a vertical layout group. Provide
-/// a prefab with a <see cref="Text"/> component for each entry.
+/// a prefab with a <see cref="TMP_Text"/> component for each entry.
 /// </summary>
 public class AchievementsMenu : MonoBehaviour
 {
     [Tooltip("Prefab used to display each achievement entry.")]
     /// <summary>
     /// Prefab used to visualise a single achievement. Must contain a
-    /// <see cref="UnityEngine.UI.Text"/> component which is populated with the
-    /// achievement name and description.
+    /// <see cref="TMP_Text"/> component which is populated with the achievement
+    /// name and description.
     /// </summary>
     public GameObject entryPrefab;
     [Tooltip("Parent transform where instantiated entries are placed.")]
@@ -77,7 +77,8 @@ public class AchievementsMenu : MonoBehaviour
             SteamUserStats.GetAchievement(id, out achieved);
 
             GameObject entry = Instantiate(entryPrefab, listParent);
-            Text text = entry.GetComponentInChildren<Text>();
+            // Use TextMeshPro for crisp, flexible rendering of achievement info.
+            TMP_Text text = entry.GetComponentInChildren<TMP_Text>();
             if (text != null)
             {
                 string unlocked = achieved ? LocalizationManager.Get("achievement_unlocked") : string.Empty;

--- a/Assets/Scripts/CoinBonusIndicator.cs
+++ b/Assets/Scripts/CoinBonusIndicator.cs
@@ -4,25 +4,26 @@
  * UI helper that displays the remaining duration of the coin bonus effect on
  * screen. When the bonus is inactive the label's GameObject is disabled so it
  * does not occupy layout space. Attach this script to a UI GameObject that has
- * a child Text component assigned to 'timerLabel'.
+ * a child TMP_Text component assigned to 'timerLabel'.
  * -----------------------------------------------------------------------------
  */
 
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro; // TextMeshPro provides TMP_Text for crisp UI text
 
 /// <summary>
-/// Updates a UI <see cref="Text"/> to show the current coin bonus multiplier
-/// and countdown. The label is automatically hidden when the bonus expires.
+/// Updates a UI <see cref="TMP_Text"/> to show the current coin bonus
+/// multiplier and countdown. The label is automatically hidden when the bonus
+/// expires.
 /// </summary>
 public class CoinBonusIndicator : MonoBehaviour
 {
     [Tooltip("UI text displaying multiplier and remaining seconds.")]
     /// <summary>
-    /// Label that shows the current multiplier and seconds left. When the
-    /// bonus expires this GameObject is disabled to collapse its layout.
+    /// Label that shows the current multiplier and seconds left. When the bonus
+    /// expires this GameObject is disabled to collapse its layout.
     /// </summary>
-    public Text timerLabel;
+    public TMP_Text timerLabel;
 
     /// <summary>
     /// Refreshes the bonus timer display each frame and hides the label when

--- a/Assets/Scripts/DailyChallengeUI.cs
+++ b/Assets/Scripts/DailyChallengeUI.cs
@@ -1,27 +1,42 @@
+// DailyChallengeUI.cs
+// -----------------------------------------------------------------------------
+// Presents the player's current daily challenge and progress on screen. The
+// label now uses TextMeshPro to ensure crisp rendering on all resolutions.
+// Attach this component to a panel with a TMP_Text child and optional Slider.
+// -----------------------------------------------------------------------------
 using UnityEngine;
-using UnityEngine.UI;
+using UnityEngine.UI; // Slider support remains in the legacy UI namespace
+using TMPro;           // TextMeshPro provides the TMP_Text component
 
 /// <summary>
 /// Simple UI component that displays the current daily challenge text and
-/// progress percentage. Attach this script to a panel containing a Text field
-/// and optional progress slider.
+/// progress percentage. Attach this script to a panel containing a
+/// <see cref="TMP_Text"/> field and optional progress slider.
 /// </summary>
 public class DailyChallengeUI : MonoBehaviour
 {
-    public Text challengeLabel;
+    [Tooltip("Label displaying the current daily challenge description.")]
+    public TMP_Text challengeLabel; // replaced legacy Text with TMP_Text
+    [Tooltip("Optional slider showing completion progress from 0 to 1.")]
     public Slider progressBar;
 
+    /// <summary>
+    /// Refreshes the text and progress bar every frame. If the manager is not
+    /// yet initialised the method returns early to avoid null references.
+    /// </summary>
     void Update()
     {
         if (DailyChallengeManager.Instance == null)
-            return;
+            return; // manager not ready; nothing to display yet
 
+        // Show the latest challenge description using localized text.
         challengeLabel.text = DailyChallengeManager.Instance.GetChallengeText();
 
         int target = DailyChallengeManager.Instance.GetTarget();
         int progress = DailyChallengeManager.Instance.GetProgress();
         if (progressBar != null && target > 0)
         {
+            // Slider expects a value between 0 and 1, hence the clamp.
             progressBar.value = Mathf.Clamp01(progress / (float)target);
         }
     }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
-using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System;
 using System.Collections;
+using TMPro; // TextMeshPro provides TMP_Text for UI labels
 
 /// <summary>
 /// Central controller for the endless runner. Tracks the player's
@@ -79,14 +79,19 @@ using System.Collections;
 /// <see cref="StartGame"/> with null-safe handling to prevent runtime
 /// exceptions when supporting managers or UI elements are missing.
 /// </remarks>
+/// <remarks>
+/// 2043 update: UI text elements migrated from <c>UnityEngine.UI.Text</c> to
+/// <see cref="TMP_Text"/> for higher quality rendering and to modernize the
+/// UI stack.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
     public float baseSpeed = 5f;              // initial world scroll speed
     public float speedIncrease = 0.1f;        // speed gain per second
-    public Text scoreLabel;                   // UI label showing current distance
-    public Text highScoreLabel;               // UI label showing best distance
-    public Text coinLabel;                    // UI label showing collected coins
+    public TMP_Text scoreLabel;               // UI label showing current distance
+    public TMP_Text highScoreLabel;           // UI label showing best distance
+    public TMP_Text coinLabel;                // UI label showing collected coins
     [Tooltip("Power-up prefabs that may spawn when a run begins if the player has the corresponding upgrade.")]
     public GameObject[] startingPowerUps;
 
@@ -138,7 +143,7 @@ public class GameManager : MonoBehaviour
     [SerializeField]
     private int maxComboMultiplier = 10;      // cap applied to combo multiplier for balance
 
-    public Text comboLabel;                   // UI label showing current combo multiplier
+    public TMP_Text comboLabel;               // UI label showing current combo multiplier
 
     [Header("Combo Feedback")]
     [Tooltip("Particle effect played when the combo multiplier increases.")]

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 #endif
 using System.Collections;
+using TMPro; // TextMeshPro used for binding label updates
 
 // 2024 update: added a stubbed TriggerRumble method so projects using the
 // legacy input manager still compile. Calls to TriggerRumble simply do nothing
@@ -36,6 +37,9 @@ using System.Collections;
 /// 2034 fix: rumble requests with zero or negative duration now abort before
 /// starting a coroutine, ensuring no unnecessary work is scheduled for
 /// instantaneous vibrations.
+/// 2036 update: rebinding UI labels now use <see cref="TMP_Text"/> to provide
+/// crisp, resolution-independent text and remove the dependency on legacy
+/// <c>UnityEngine.UI.Text</c> components.
 /// </summary>
 public static class InputManager
 {
@@ -448,10 +452,10 @@ public static class InputManager
     /// <summary>
     /// Begins an interactive rebinding operation for the jump action.
     /// The provided MonoBehaviour is used to start a coroutine so the
-    /// operation can run asynchronously. The label is updated with the
-    /// human readable binding string when complete.
+    /// operation can run asynchronously. The TMP_Text label is updated
+    /// with the human readable binding string when complete.
     /// </summary>
-    public static void StartRebindJump(MonoBehaviour owner, UnityEngine.UI.Text label)
+    public static void StartRebindJump(MonoBehaviour owner, TMP_Text label)
     {
         owner.StartCoroutine(RebindRoutine(jumpAction, JumpBindingPref, label));
     }
@@ -459,7 +463,7 @@ public static class InputManager
     /// <summary>
     /// Begins an interactive rebinding operation for the slide action.
     /// </summary>
-    public static void StartRebindSlide(MonoBehaviour owner, UnityEngine.UI.Text label)
+    public static void StartRebindSlide(MonoBehaviour owner, TMP_Text label)
     {
         owner.StartCoroutine(RebindRoutine(slideAction, SlideBindingPref, label));
     }
@@ -468,7 +472,7 @@ public static class InputManager
     /// Begins an interactive rebinding operation for the down action.
     /// This input is used for fast falling.
     /// </summary>
-    public static void StartRebindDown(MonoBehaviour owner, UnityEngine.UI.Text label)
+    public static void StartRebindDown(MonoBehaviour owner, TMP_Text label)
     {
         owner.StartCoroutine(RebindRoutine(downAction, DownBindingPref, label));
     }
@@ -476,13 +480,13 @@ public static class InputManager
     /// <summary>
     /// Begins an interactive rebinding operation for the pause action.
     /// </summary>
-    public static void StartRebindPause(MonoBehaviour owner, UnityEngine.UI.Text label)
+    public static void StartRebindPause(MonoBehaviour owner, TMP_Text label)
     {
         owner.StartCoroutine(RebindRoutine(pauseAction, PauseBindingPref, label));
     }
 
     // Coroutine that waits for the user to press a new control and stores the result.
-    private static System.Collections.IEnumerator RebindRoutine(InputAction action, string pref, UnityEngine.UI.Text label)
+    private static System.Collections.IEnumerator RebindRoutine(InputAction action, string pref, TMP_Text label)
     {
         action.Disable();
         var operation = action.PerformInteractiveRebinding()

--- a/Assets/Scripts/SettingsMenu.cs
+++ b/Assets/Scripts/SettingsMenu.cs
@@ -1,5 +1,12 @@
+// SettingsMenu.cs
+// -----------------------------------------------------------------------------
+// Handles runtime configuration options such as key bindings, audio levels and
+// accessibility toggles. Text fields now use TextMeshPro's TMP_Text for improved
+// clarity across resolutions.
+// -----------------------------------------------------------------------------
 using UnityEngine;
-using UnityEngine.UI;
+using UnityEngine.UI; // Sliders, Toggles and Dropdown remain in this namespace
+using TMPro;          // Provides the TMP_Text components for labels
 using System.Collections.Generic;
 
 /// <summary>
@@ -9,14 +16,14 @@ using System.Collections.Generic;
 /// </summary>
 public class SettingsMenu : MonoBehaviour
 {
-    public Text jumpKeyLabel;
-    public Text slideKeyLabel;
-    public Text pauseKeyLabel;
+    public TMP_Text jumpKeyLabel;
+    public TMP_Text slideKeyLabel;
+    public TMP_Text pauseKeyLabel;
     public Toggle colorblindToggle;
     public Slider musicVolumeSlider;
-    public Text musicVolumeLabel;
+    public TMP_Text musicVolumeLabel;
     public Slider effectsVolumeSlider;
-    public Text effectsVolumeLabel;
+    public TMP_Text effectsVolumeLabel;
     public Dropdown languageDropdown;
     public Toggle rumbleToggle;
     public Toggle hardcoreToggle; // toggle for hardcore mode

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -30,14 +30,18 @@
 // background sprite without repeated FindObjectOfType calls. This reduces
 // per-frame allocations and avoids null reference errors when the background
 // is absent.
+// 2036 update summary
+// Migrates UI text elements to TextMeshPro's TMP_Text for sharper rendering
+// and to remove the legacy UnityEngine.UI.Text dependency.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
+using UnityEngine.UI; // Retained for Slider and other legacy UI components
 #if UNITY_STANDALONE
 using Steamworks;
 #endif
+using TMPro; // TextMeshPro for TMP_Text components
 using System.Collections.Generic;
 using System.Collections;
 using System.IO;
@@ -67,17 +71,17 @@ public class UIManager : MonoBehaviour
     public GameObject gameOverPanel;
     public GameObject pausePanel;
     public GameObject settingsPanel;
-    public Text finalScoreLabel;
-    public Text highScoreLabel;
-    public Text coinScoreLabel;
+    public TMP_Text finalScoreLabel;
+    public TMP_Text highScoreLabel;
+    public TMP_Text coinScoreLabel;
     public GameObject leaderboardPanel;
-    public Text leaderboardText;
+    public TMP_Text leaderboardText;
     [Tooltip("Client used for non-Steam leaderboard requests.")]
     public LeaderboardClient leaderboardClient;
     public GameObject workshopPanel;
     public GameObject achievementsPanel;
     public GameObject shopPanel;
-    public Text workshopListText;
+    public TMP_Text workshopListText;
     [Tooltip("Panel containing a simple loading indicator graphic.")]
     public GameObject loadingPanel;
     [Tooltip("Optional slider visualizing loading progress from 0 to 1.")]
@@ -592,9 +596,10 @@ public class UIManager : MonoBehaviour
 
     /// <summary>
     /// Performs a brief scaling animation on the provided combo multiplier
-    /// label to draw the player's attention when the value changes.
+    /// label to draw the player's attention when the value changes. Uses
+    /// <see cref="TMP_Text"/> to leverage TextMeshPro rendering.
     /// </summary>
-    public void AnimateComboLabel(Text label)
+    public void AnimateComboLabel(TMP_Text label)
     {
         if (label != null)
         {
@@ -603,7 +608,7 @@ public class UIManager : MonoBehaviour
     }
 
     // Coroutine that smoothly scales the label up and back down.
-    private IEnumerator ScaleLabel(Text label)
+    private IEnumerator ScaleLabel(TMP_Text label)
     {
         const float duration = 0.2f;
         Vector3 baseScale = label.transform.localScale;

--- a/Assets/Tests/EditMode/CoinBonusIndicatorTests.cs
+++ b/Assets/Tests/EditMode/CoinBonusIndicatorTests.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro; // Use TextMeshPro for UI elements in tests
 
 /// <summary>
 /// Tests for the CoinBonusIndicator component ensuring it shows and hides
@@ -16,7 +16,7 @@ public class CoinBonusIndicatorTests
         gm.StartGame();
 
         var uiObj = new GameObject("ui");
-        var text = uiObj.AddComponent<Text>();
+        var text = uiObj.AddComponent<TextMeshProUGUI>();
         var ind = uiObj.AddComponent<CoinBonusIndicator>();
         ind.timerLabel = text;
 

--- a/Assets/Tests/EditMode/ComboMultiplierTests.cs
+++ b/Assets/Tests/EditMode/ComboMultiplierTests.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro; // Using TextMeshPro components in tests
 using System.Reflection;
 
 /// <summary>
@@ -30,7 +30,8 @@ public class ComboMultiplierTests
 
         // Provide a label so UpdateMultiplierLabel can display the current value.
         var labelObj = new GameObject("label");
-        gm.comboLabel = labelObj.AddComponent<Text>();
+        // TextMeshProUGUI simulates the in-game combo label for testing.
+        gm.comboLabel = labelObj.AddComponent<TextMeshProUGUI>();
 
         // Read the configured cap via reflection to keep the test flexible.
         int max = (int)typeof(GameManager).GetField("maxComboMultiplier", BindingFlags.NonPublic | BindingFlags.Instance)

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using UnityEngine.UI;               // Needed for assigning UI Text references
+using TMPro;               // Needed for assigning TMP_Text references
 using System;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -32,16 +32,16 @@ public class GameManagerTests
         var go = new GameObject("gm");
         var gm = go.AddComponent<T>();
 
-        gm.scoreLabel = new GameObject("scoreLabel").AddComponent<Text>();
+        gm.scoreLabel = new GameObject("scoreLabel").AddComponent<TextMeshProUGUI>();
         gm.scoreLabel.transform.SetParent(go.transform);
 
-        gm.highScoreLabel = new GameObject("highScoreLabel").AddComponent<Text>();
+        gm.highScoreLabel = new GameObject("highScoreLabel").AddComponent<TextMeshProUGUI>();
         gm.highScoreLabel.transform.SetParent(go.transform);
 
-        gm.coinLabel = new GameObject("coinLabel").AddComponent<Text>();
+        gm.coinLabel = new GameObject("coinLabel").AddComponent<TextMeshProUGUI>();
         gm.coinLabel.transform.SetParent(go.transform);
 
-        gm.comboLabel = new GameObject("comboLabel").AddComponent<Text>();
+        gm.comboLabel = new GameObject("comboLabel").AddComponent<TextMeshProUGUI>();
         gm.comboLabel.transform.SetParent(go.transform);
 
         return gm;

--- a/Assets/Tests/EditMode/UIManagerTests.cs
+++ b/Assets/Tests/EditMode/UIManagerTests.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro; // TextMeshPro components used for UI labels
 using System.Collections.Generic;
 using System.IO;
 
@@ -25,7 +25,7 @@ public class UIManagerTests
         var uiObj = new GameObject("ui");
         var ui = uiObj.AddComponent<UIManager>();
         var textObj = new GameObject("txt");
-        var text = textObj.AddComponent<Text>();
+        var text = textObj.AddComponent<TextMeshProUGUI>();
         ui.leaderboardText = text;
 
         // Simulate a failed leaderboard retrieval.


### PR DESCRIPTION
## Summary
- migrate UI labels from `UnityEngine.UI.Text` to TextMeshPro `TMP_Text`
- update settings, rebind routines, and managers to use TextMeshPro
- adjust unit tests to instantiate `TextMeshProUGUI` components

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found)*
- `npm test`