### PR TITLE
Expose enemy target assignment and add movement tests

### DIFF
--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -1,8 +1,12 @@
 // EnemyBehavior.cs
 // -----------------------------------------------------------------------------
-// AI controller for simple flying enemies that pursue the player horizontally.
-// Movement now uses world coordinates so rotation does not influence the
-// direction of travel, preventing erratic paths for rotated enemies.
+// AI controller for simple flying enemies that pursue a designated target.
+// The original implementation searched the scene for a GameObject tagged
+// "Player" during Start(), which was both fragile and performed an expensive
+// lookup.  This revision exposes a public SetTarget method so spawners can
+// explicitly provide the player Transform when enemies are created. Movement
+// continues to use world coordinates so rotation does not influence the chase
+// direction, preventing erratic paths for rotated enemies.
 // -----------------------------------------------------------------------------
 using UnityEngine;
 
@@ -13,27 +17,26 @@ using UnityEngine;
 /// </summary>
 public class EnemyBehavior : MonoBehaviour
 {
-    // Movement speed in world units per second.
+    // Movement speed in world units per second. Public so designers can tune
+    // values in the Unity inspector.
     public float speed = 3f;
 
-    // Cached reference to the player transform for efficient lookups.
+    // Cached reference to the target the enemy should pursue. Marked
+    // [SerializeField] so a target can optionally be assigned in the inspector
+    // for scenes that do not use the provided SetTarget method. When left null,
+    // the enemy simply idles.
+    [SerializeField, Tooltip("Transform this enemy will chase. Set via SetTarget or assign in inspector.")]
     private Transform player;
 
     /// <summary>
-    /// Locates the player object so the enemy can chase it. If no player is
-    /// found, the enemy remains idle. Assumes a GameObject tagged "Player"
-    /// exists in the scene.
+    /// Assigns the Transform the enemy should chase.
     /// </summary>
-    void Start()
+    /// <param name="target">Transform of the player or other object to pursue. May be null to clear the target.</param>
+    public void SetTarget(Transform target)
     {
-        GameObject obj = GameObject.FindGameObjectWithTag("Player");
-
-        // If the player is not found the enemy cannot move; leaving player null
-        // gracefully halts Update movement logic.
-        if (obj != null)
-        {
-            player = obj.transform;
-        }
+        // Direct assignment is sufficient—callers control when the target is
+        // valid. Passing null intentionally leaves the enemy idle.
+        player = target;
     }
 
     /// <summary>
@@ -43,19 +46,25 @@ public class EnemyBehavior : MonoBehaviour
     /// </summary>
     void Update()
     {
-        // Abort if no player has been located or the game is currently paused
-        // or stopped.
+        // Abort when no target is assigned. The check prevents null reference
+        // errors if SetTarget has not been called or the caller intentionally
+        // cleared the target so the enemy should remain idle.
         if (player == null)
         {
             return;
         }
+
+        // Ensure the game is currently running before applying movement. This
+        // mirrors the behaviour of other scripts that pause when gameplay is
+        // halted by GameManager.
         if (GameManager.Instance == null || !GameManager.Instance.IsRunning())
         {
             return;
         }
 
-        // Calculate the normalized direction vector toward the player and move
-        // the enemy using world coordinates to remain independent of rotation.
+        // Calculate the normalized direction vector toward the target and move
+        // the enemy using world coordinates. Using Space.World keeps pursuit
+        // behaviour consistent regardless of the enemy's own rotation.
         Vector3 dir = (player.position - transform.position).normalized;
         transform.Translate(dir * speed * Time.deltaTime, Space.World);
     }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -84,6 +84,11 @@ using TMPro; // TextMeshPro provides TMP_Text for UI labels
 /// <see cref="TMP_Text"/> for higher quality rendering and to modernize the
 /// UI stack.
 /// </remarks>
+/// <remarks>
+/// 2045 update: exposes <see cref="PlayerTransform"/> so external systems can
+/// access the player's <see cref="Transform"/> directly instead of performing
+/// costly scene searches for a tagged object.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -112,6 +117,22 @@ public class GameManager : MonoBehaviour
 
     [SerializeField]
     private GameObject playerObject;          // cached reference to the player GameObject; assign via inspector
+
+    /// <summary>
+    /// Provides read-only access to the player's <see cref="Transform"/>. The
+    /// reference is null when the player object has not been assigned in the
+    /// inspector, allowing callers to safely handle missing dependencies.
+    /// </summary>
+    public Transform PlayerTransform
+    {
+        get
+        {
+            // Return the transform of the serialized player object when
+            // available. The null-conditional prevents dereferencing a missing
+            // player and keeps callers robust in unconfigured scenes.
+            return playerObject != null ? playerObject.transform : null;
+        }
+    }
 
     // Coin bonus power-up variables
     private float coinBonusTimer;             // remaining time coins are multiplied

--- a/Assets/Scripts/HazardSpawner.cs
+++ b/Assets/Scripts/HazardSpawner.cs
@@ -5,6 +5,13 @@ using UnityEngine;
 /// frequency increases with the player's distance. Supports object
 /// pooling for performance. Stage-specific spawn weights and a
 /// difficulty multiplier are applied by <see cref="StageManager"/>.
+/// 
+/// <remarks>
+/// 2045 update: After spawning an enemy that uses <see cref="EnemyBehavior"/>,
+/// the spawner now assigns the player's transform directly via
+/// <see cref="EnemyBehavior.SetTarget"/>. This eliminates scene searches for
+/// a "Player" tag and ensures pooled enemies immediately know who to pursue.
+/// </remarks>
 /// </summary>
 public class HazardSpawner : MonoBehaviour
 {
@@ -181,6 +188,16 @@ public class HazardSpawner : MonoBehaviour
             obj.GetComponent<ShooterEnemy>() == null)
         {
             obj.AddComponent<EnemyBehavior>();
+        }
+
+        // Provide the freshly spawned enemy with the player's transform so it
+        // can immediately begin chasing without performing a scene search. When
+        // the GameManager or player reference is missing the enemy remains idle
+        // thanks to the null checks inside EnemyBehavior.Update().
+        if (obj != null && GameManager.Instance != null)
+        {
+            var behavior = obj.GetComponent<EnemyBehavior>();
+            behavior?.SetTarget(GameManager.Instance.PlayerTransform);
         }
     }
 

--- a/Assets/Tests/EditMode/EnemyBehaviorTests.cs
+++ b/Assets/Tests/EditMode/EnemyBehaviorTests.cs
@@ -1,25 +1,34 @@
 // EnemyBehaviorTests.cs
 // -----------------------------------------------------------------------------
-// Validates that EnemyBehavior moves enemies toward the player using world
-// coordinates, ensuring rotation does not alter the pursuit path.
+// Validates behaviour of EnemyBehavior including rotation-independent
+// movement and the requirement for an explicitly assigned target. The tests
+// simulate Unity's game loop by manually invoking Update after configuring a
+// running GameManager and providing target transforms.
 // -----------------------------------------------------------------------------
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
 
 /// <summary>
-/// Test suite verifying the rotation-independent movement of EnemyBehavior.
+/// Test suite verifying EnemyBehavior functionality.
 /// </summary>
 public class EnemyBehaviorTests
 {
     /// <summary>
     /// Ensures that two enemies, one rotated and one not, move identically
     /// toward the player, demonstrating that movement calculations occur in
-    /// world space.
+    /// world space and are unaffected by the enemy's orientation.
     /// </summary>
     [Test]
     public void Update_MovementIndependentOfRotation()
     {
+        // Create a running GameManager so EnemyBehavior.Update processes
+        // movement. The field is private so reflection is used to set it.
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("isRunning", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, true);
+
         // Create a player target positioned to the right of the origin.
         var player = new GameObject("player");
         player.transform.position = new Vector3(5f, 0f, 0f);
@@ -31,11 +40,10 @@ public class EnemyBehaviorTests
         enemyB.transform.rotation = Quaternion.Euler(0f, 0f, 90f);
         var behaviorB = enemyB.AddComponent<EnemyBehavior>();
 
-        // Manually assign the private player field via reflection so Update can
-        // execute without invoking Start().
-        var field = typeof(EnemyBehavior).GetField("player", BindingFlags.NonPublic | BindingFlags.Instance);
-        field.SetValue(behaviorA, player.transform);
-        field.SetValue(behaviorB, player.transform);
+        // Assign the shared player target using the new SetTarget API instead of
+        // relying on a tag lookup.
+        behaviorA.SetTarget(player.transform);
+        behaviorB.SetTarget(player.transform);
 
         // Invoke Update on both behaviors to move them toward the player.
         behaviorA.Update();
@@ -49,5 +57,50 @@ public class EnemyBehaviorTests
         Object.DestroyImmediate(enemyA);
         Object.DestroyImmediate(enemyB);
         Object.DestroyImmediate(player);
+        Object.DestroyImmediate(gmObj);
+    }
+
+    /// <summary>
+    /// Verifies that enemies only move when provided a valid target via
+    /// <see cref="EnemyBehavior.SetTarget"/> and remain stationary otherwise.
+    /// </summary>
+    [Test]
+    public void Update_MovementRequiresTarget()
+    {
+        // Create a running GameManager to satisfy the update checks.
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        typeof(GameManager).GetField("isRunning", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, true);
+
+        // Player transform located one unit to the right.
+        var player = new GameObject("player");
+        player.transform.position = Vector3.right;
+
+        // Enemy that receives a target and should therefore move.
+        var enemyWithTarget = new GameObject("enemyWithTarget");
+        var behaviorWithTarget = enemyWithTarget.AddComponent<EnemyBehavior>();
+        behaviorWithTarget.SetTarget(player.transform);
+
+        // Enemy left without a target which should stay idle.
+        var enemyWithoutTarget = new GameObject("enemyWithoutTarget");
+        var behaviorWithoutTarget = enemyWithoutTarget.AddComponent<EnemyBehavior>();
+
+        // Perform a single update cycle for both enemies.
+        behaviorWithTarget.Update();
+        behaviorWithoutTarget.Update();
+
+        // Enemy with a target should have moved away from the origin whereas the
+        // idle enemy should remain in place.
+        Assert.AreNotEqual(Vector3.zero, enemyWithTarget.transform.position,
+            "Enemy provided a target is expected to move toward it.");
+        Assert.AreEqual(Vector3.zero, enemyWithoutTarget.transform.position,
+            "Enemy without a target should remain stationary.");
+
+        // Clean up spawned objects.
+        Object.DestroyImmediate(enemyWithTarget);
+        Object.DestroyImmediate(enemyWithoutTarget);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(gmObj);
     }
 }


### PR DESCRIPTION
## Summary
- allow spawners to inject a player Transform through `EnemyBehavior.SetTarget`
- assign player target to spawned hazards and expose `GameManager.PlayerTransform`
- verify enemies move with a target and idle otherwise

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76c86f818832189a953e2daaab443