### PR TITLE
Centralize time scaling in GameManager and add pause test

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -94,6 +94,12 @@ using TMPro; // TextMeshPro provides TMP_Text for UI labels
 /// <see cref="MaxSpeed"/> for systems that scale difficulty based on the
 /// game's top velocity.
 /// </remarks>
+/// <remarks>
+/// 2050 update: pausing now sets <c>Time.timeScale</c> to <c>0</c> and resuming or
+/// starting a run restores it to <c>1</c>. Centralizing time control here ensures
+/// all gameplay and physics-based systems halt uniformly when the game is
+/// paused and resume predictably.
+/// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
 {
@@ -625,6 +631,8 @@ public class GameManager : MonoBehaviour
 
         stageSpeedMultiplier = 1f;
         slowMotionTimer = 0f;
+        // Ensure global time runs at normal speed in case a previous session
+        // paused the game or slow motion was active.
         Time.timeScale = 1f;
 
         // Validate required references and spawn starting power-ups if configured.
@@ -663,8 +671,13 @@ public class GameManager : MonoBehaviour
     public void PauseGame()
     {
         if (!isRunning || isPaused) return;
+
+        // Flag gameplay as inactive and freeze time so all Update and physics
+        // calculations stop. Using Time.timeScale ensures any running
+        // coroutines or animations tied to scaled time also pause.
         isRunning = false;
         isPaused = true;
+        Time.timeScale = 0f;
     }
 
     /// <summary>
@@ -673,8 +686,13 @@ public class GameManager : MonoBehaviour
     public void ResumeGame()
     {
         if (!isPaused) return;
+
+        // Reactivate gameplay and restore normal time progression so movement
+        // and physics resume. This mirrors the behavior in StartGame so all
+        // entry points use consistent time scaling.
         isRunning = true;
         isPaused = false;
+        Time.timeScale = 1f;
     }
 
     /// <summary>

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -33,6 +33,10 @@
 // 2036 update summary
 // Migrates UI text elements to TextMeshPro's TMP_Text for sharper rendering
 // and to remove the legacy UnityEngine.UI.Text dependency.
+// 2050 update summary
+// Global time scaling is now controlled exclusively by GameManager. UIManager
+// no longer modifies Time.timeScale when pausing or resuming, preventing
+// redundant state changes.
 // -----------------------------------------------------------------------------
 
 using UnityEngine;
@@ -388,9 +392,10 @@ public class UIManager : MonoBehaviour
         ShowPanel(pausePanel);
         if (GameManager.Instance != null)
         {
+            // Delegates the actual pausing and time-scale adjustment to
+            // GameManager so only one system controls global time state.
             GameManager.Instance.PauseGame();
         }
-        Time.timeScale = 0f;
     }
 
     /// <summary>
@@ -401,9 +406,9 @@ public class UIManager : MonoBehaviour
         HidePanel(pausePanel);
         if (GameManager.Instance != null)
         {
+            // GameManager restores normal gameplay and resets time scale.
             GameManager.Instance.ResumeGame();
         }
-        Time.timeScale = 1f;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -20,6 +20,10 @@ using System.Text.RegularExpressions;
 /// 2047 update: adds coverage ensuring <see cref="GameManager"/> clamps its
 /// internal speed to the configured maximum value.
 /// </remarks>
+/// <remarks>
+/// 2050 update: introduces tests confirming that pausing the game freezes
+/// object movement by setting <c>Time.timeScale</c> to zero.
+/// </remarks>
 
 // EditMode tests can be run through Unity's Test Runner window.
 // Create this file under Assets/Tests/EditMode and open Window > General > Test Runner.
@@ -348,6 +352,45 @@ public class GameManagerTests
         update.Invoke(gm, null);
 
         Assert.AreEqual(1f, Time.timeScale);
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(player);
+    }
+
+    /// <summary>
+    /// Pausing the game should freeze <see cref="Time.timeScale"/> and prevent
+    /// objects that rely on <see cref="GameManager.IsRunning"/> from moving.
+    /// </summary>
+    [Test]
+    public void PauseGame_StopsObjectMovement()
+    {
+        // Create GameManager with required UI and a dummy player for StartGame.
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
+        var player = new GameObject("player");
+        typeof(GameManager).GetField("playerObject", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, player);
+
+        gm.StartGame();
+
+        // Spawn a ZigZagEnemy which consults IsRunning() before moving.
+        var enemyObj = new GameObject("enemy");
+        var enemy = enemyObj.AddComponent<ZigZagEnemy>();
+        enemy.OnEnable();
+
+        // Run one update to establish a baseline position.
+        enemy.Update();
+        Vector3 posBeforePause = enemyObj.transform.position;
+
+        // Pausing should set timeScale to zero and halt further movement.
+        gm.PauseGame();
+        enemy.Update();
+        Vector3 posAfterPause = enemyObj.transform.position;
+
+        Assert.AreEqual(posBeforePause, posAfterPause, "Enemy should not move while game is paused.");
+
+        // Resume to restore time scale for subsequent tests and clean up.
+        gm.ResumeGame();
+        Object.DestroyImmediate(enemyObj);
         Object.DestroyImmediate(go);
         Object.DestroyImmediate(player);
     }


### PR DESCRIPTION
## Summary
- Freeze world time during `GameManager.PauseGame` and restore on resume/start
- Delegate time-scale changes from `UIManager` to `GameManager`
- Add unit test verifying enemies stop moving when the game is paused

## Testing
- `npm test`