### PR TITLE
Improve grounded ray direction

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -29,6 +29,10 @@ using UnityEngine;
 // correctly if game modes invert gravity.
 // 2026 fix: Air-dive logic now guards against zero gravity to prevent
 // undefined velocity when Physics2D.gravity is a zero vector.
+// 2030 enhancement: Ground checking now derives the ray direction from
+// Physics2D.gravity.normalized and projects collider bounds along that
+// vector. This supports diagonal and zero-gravity scenarios by falling back to
+// <c>Vector2.down</c> when gravity's magnitude is negligible.
 [RequireComponent(typeof(Rigidbody2D), typeof(CapsuleCollider2D), typeof(Animator))]
 public class PlayerController : MonoBehaviour
 {
@@ -289,20 +293,26 @@ public class PlayerController : MonoBehaviour
         // the collider is resized for sliding.
         Vector2 origin = coll.bounds.center;
 
-        // Calculate the ray length dynamically based on the collider's vertical
-        // extents. This allows ground detection to scale with both very small
-        // and very large colliders. A small skin width avoids floating-point
-        // precision issues that could otherwise report false negatives. Using
-        // <c>bounds.extents</c> instead of a fixed constant also means the logic
-        // remains correct if gravity is inverted (positive Y), since the ray is
-        // cast from the center in the direction of gravity and always reaches
-        // beyond the collider's edge.
-        float distance = coll.bounds.extents.y + 0.1f;
+        // Determine the ray direction from the current gravity vector. This
+        // supports diagonal or even inverted gravity configurations used by
+        // certain power-ups or game modes. Physics2D.gravity.normalized will
+        // produce NaN when gravity is exactly zero, so we explicitly fall back to
+        // Vector2.down in that case so the player can still detect the ground
+        // during zero-gravity sections.
+        Vector2 gravity = Physics2D.gravity;
+        Vector2 rayDir = gravity.sqrMagnitude > 0.0001f ? gravity.normalized : Vector2.down;
 
-        // Choose the ray direction based on the sign of gravity. When gravity is
-        // flipped upward, the raycast travels upward so the player can still
-        // detect "ground" above them.
-        Vector2 rayDir = Physics2D.gravity.y > 0f ? Vector2.up : Vector2.down;
+        // Calculate the ray length by projecting the collider's extents onto the
+        // ray direction. This yields the half-size of the collider along that
+        // direction, ensuring the ray always reaches just beyond the edge of the
+        // collider regardless of its dimensions or the gravity orientation. A
+        // small skin width avoids precision issues that might otherwise miss
+        // surfaces resting directly against the collider.
+        Vector3 extents3 = coll.bounds.extents;
+        Vector2 extents = new Vector2(extents3.x, extents3.y);
+        Vector2 absDir = new Vector2(Mathf.Abs(rayDir.x), Mathf.Abs(rayDir.y));
+        float distance = Vector2.Dot(extents, absDir) + 0.1f;
+
         RaycastHit2D hit = Physics2D.Raycast(origin, rayDir, distance, groundLayer);
         bool wasGrounded = isGrounded;
         isGrounded = hit.collider != null;

--- a/Assets/Tests/EditMode/PlayerControllerTests.cs
+++ b/Assets/Tests/EditMode/PlayerControllerTests.cs
@@ -6,6 +6,8 @@
 // a GameObject lacking those dependencies.
 // 2029 update: Physics behaviour moved to FixedUpdate; tests call it explicitly
 // to exercise queued forces and velocity changes.
+// 2030 update: Adds regression tests for diagonal and zero-gravity ground
+// detection to ensure CheckGrounded handles non-standard gravity vectors.
 
 using NUnit.Framework;
 using UnityEngine;
@@ -22,7 +24,9 @@ using UnityEngine.InputSystem;
 /// colliders. 2026 update: adds a regression test ensuring the air-dive
 /// defaults to <see cref="Vector2.down"/> when gravity is zero, preventing NaN
 /// velocities. 2029 update: physics-affecting tests explicitly invoke
-/// <c>FixedUpdate</c> to process queued forces.
+/// <c>FixedUpdate</c> to process queued forces. 2030 update: additional tests
+/// cover diagonal gravity and zero-gravity cases to validate the enhanced
+/// ground ray direction logic.
 /// </summary>
 public class PlayerControllerTests
 {
@@ -268,6 +272,77 @@ public class PlayerControllerTests
             .GetValue(pc);
         Assert.IsTrue(grounded, "Ray length based on collider bounds should register the ground");
 
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(ground);
+    }
+
+    [Test]
+    public void GroundCheck_RespectsDiagonalGravity()
+    {
+        // When gravity points diagonally, CheckGrounded should cast along that
+        // vector and still detect surfaces positioned in the same direction.
+        var player = new GameObject("player");
+        player.AddComponent<Rigidbody2D>();
+        var col = player.AddComponent<CapsuleCollider2D>();
+        col.size = new Vector2(1f, 1f);
+        var pc = player.AddComponent<PlayerController>();
+        pc.groundLayer = LayerMask.GetMask("Default");
+
+        // Use a diagonal gravity vector and place the ground along that path.
+        Vector2 gravity = new Vector2(5f, -5f);
+        Physics2D.gravity = gravity;
+        Vector2 rayDir = gravity.normalized;
+        Vector3 extents3 = col.bounds.extents;
+        Vector2 extents = new Vector2(extents3.x, extents3.y);
+        Vector2 absDir = new Vector2(Mathf.Abs(rayDir.x), Mathf.Abs(rayDir.y));
+        float distance = Vector2.Dot(extents, absDir) + 0.05f;
+
+        var ground = new GameObject("ground");
+        ground.AddComponent<BoxCollider2D>();
+        Vector2 groundPos = (Vector2)player.transform.position + rayDir * distance;
+        ground.transform.position = new Vector3(groundPos.x, groundPos.y, 0f);
+
+        typeof(PlayerController)
+            .GetMethod("CheckGrounded", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pc, null);
+
+        bool grounded = (bool)typeof(PlayerController)
+            .GetField("isGrounded", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(pc);
+        Assert.IsTrue(grounded, "Ray should hit ground along diagonal gravity");
+
+        Physics2D.gravity = new Vector2(0f, -9.81f);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(ground);
+    }
+
+    [Test]
+    public void GroundCheck_DefaultsDownWithZeroGravity()
+    {
+        // With zero gravity the ray should fall back to Vector2.down so ground
+        // directly beneath the player is still detected.
+        var player = new GameObject("player");
+        player.AddComponent<Rigidbody2D>();
+        player.AddComponent<CapsuleCollider2D>();
+        var pc = player.AddComponent<PlayerController>();
+        pc.groundLayer = LayerMask.GetMask("Default");
+
+        Physics2D.gravity = Vector2.zero;
+
+        var ground = new GameObject("ground");
+        ground.AddComponent<BoxCollider2D>();
+        ground.transform.position = new Vector3(0f, -0.05f, 0f);
+
+        typeof(PlayerController)
+            .GetMethod("CheckGrounded", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(pc, null);
+
+        bool grounded = (bool)typeof(PlayerController)
+            .GetField("isGrounded", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(pc);
+        Assert.IsTrue(grounded, "Ray should default downward when gravity is zero");
+
+        Physics2D.gravity = new Vector2(0f, -9.81f);
         Object.DestroyImmediate(player);
         Object.DestroyImmediate(ground);
     }


### PR DESCRIPTION
## Summary
- derive ground-check ray direction from `Physics2D.gravity`, defaulting to `Vector2.down` when gravity is zero
- project collider bounds along gravity direction to compute ray distance
- add diagonal and zero-gravity unit tests for `CheckGrounded`

## Testing
- `npm test`