### PR TITLE
Flush pending saves on destroy

### DIFF
--- a/Assets/Scripts/SaveGameManager.cs
+++ b/Assets/Scripts/SaveGameManager.cs
@@ -34,6 +34,8 @@
 // 2034 update: Queue processing now reports failures when temporary save files
 // cannot be deleted, aiding diagnosis of cleanup issues that previously went
 // unnoticed.
+// 2035 update: OnDestroy now waits briefly for queued saves to flush so data
+// persists even when the manager is destroyed without the quit path.
 // -----------------------------------------------------------------------------
 
 using System;
@@ -128,9 +130,9 @@ public class SaveGameManager : MonoBehaviour
     private readonly Queue<SaveRequest> saveQueue = new Queue<SaveRequest>();
     private Task processingTask = Task.CompletedTask;
     private readonly ConcurrentQueue<Action> completionActions = new ConcurrentQueue<Action>();
-    // Maximum time to wait for pending saves during application shutdown. A
-    // short timeout prevents the game from hanging indefinitely if the disk is
-    // unresponsive.
+    // Maximum time to wait for pending saves during application shutdown or
+    // destruction. A short timeout prevents the game from hanging indefinitely
+    // if the disk is unresponsive.
     private static readonly TimeSpan ShutdownFlushTimeout = TimeSpan.FromSeconds(2);
 
     // ---------------------------------------------------------------------
@@ -707,12 +709,19 @@ public class SaveGameManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Unsubscribes from global events and executes any pending completion
-    /// callbacks. Flushing of save data is handled separately when the
-    /// application quits to avoid blocking destruction.
+    /// Flushes pending save operations with a short timeout before
+    /// unsubscribing from global events and executing any remaining completion
+    /// callbacks. A synchronous wait ensures queued data reaches disk even if
+    /// the manager is destroyed without the application quitting.
     /// </summary>
     void OnDestroy()
     {
+        // Block briefly to flush any queued saves. Using GetAwaiter().GetResult
+        // ensures that asynchronous file writes complete before the manager is
+        // destroyed, avoiding data loss when destruction occurs without a quit
+        // event.
+        FlushPendingSavesAsync(ShutdownFlushTimeout).GetAwaiter().GetResult();
+
         // Remove event subscription to avoid callbacks to a destroyed instance.
         Application.quitting -= HandleApplicationQuitting;
 

--- a/Assets/Tests/EditMode/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/SaveGameManagerTests.cs
@@ -454,4 +454,26 @@ public class SaveGameManagerTests
         FlushAndDestroy(mgr2);
         FlushAndDestroy(mgr);
     }
+
+    /// <summary>
+    /// Destroying the manager should block briefly to flush pending saves so a
+    /// subsequent instance immediately observes the persisted data.
+    /// </summary>
+    [Test]
+    public void OnDestroy_FlushesPendingSaves()
+    {
+        var mgr = CreateManager<SlowSaveGameManager>("save");
+        mgr.Coins = 5; // queue save
+
+        var timer = Stopwatch.StartNew();
+        Object.DestroyImmediate(mgr.gameObject); // invokes OnDestroy synchronously
+        timer.Stop();
+        Assert.GreaterOrEqual(timer.ElapsedMilliseconds, 190,
+            "OnDestroy should wait for the slow flush to finish");
+
+        var mgr2 = CreateManager<SaveGameManager>("check");
+        Assert.AreEqual(5, mgr2.Coins, "Data should persist after OnDestroy");
+
+        FlushAndDestroy(mgr2);
+    }
 }


### PR DESCRIPTION
## Summary
- Flush pending saves with a 2s timeout when `SaveGameManager` is destroyed
- Wait synchronously for flush to complete before unsubscribing from events
- Add unit test confirming destruction writes queued data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a79ab9292c83219cda7a266dc36731