### PR TITLE
feat: allow targeting specific gamepad for rumble

### DIFF
--- a/Assets/Scripts/CoinBonusPowerUp.cs
+++ b/Assets/Scripts/CoinBonusPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Allows specifying which gamepad to rumble
+#endif
 
 /// <summary>
 /// Grants a temporary multiplier to all coin pickups when collected. The
@@ -42,7 +45,12 @@ public class CoinBonusPowerUp : MonoBehaviour
         {
             AudioManager.Instance.PlaySound(collectClip);
         }
+#if ENABLE_INPUT_SYSTEM
+        // Provide immediate tactile feedback on the active controller.
+        InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
         InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
         // Return to pool if pooled, otherwise destroy.
         PooledObject po = GetComponent<PooledObject>();
         if (po != null && po.Pool != null)

--- a/Assets/Scripts/DoubleJumpPowerUp.cs
+++ b/Assets/Scripts/DoubleJumpPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Enable routing rumble to active gamepad
+#endif
 
 /// <summary>
 /// Grants the player an additional air jump for a limited time when collected.
@@ -47,7 +50,12 @@ public class DoubleJumpPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+#if ENABLE_INPUT_SYSTEM
+            // Rumble the player's current controller to acknowledge the pickup.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
 
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)

--- a/Assets/Scripts/GravityFlipPowerUp.cs
+++ b/Assets/Scripts/GravityFlipPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Needed for specifying the target gamepad
+#endif
 
 /// <summary>
 /// Temporarily flips global gravity when collected.
@@ -28,7 +31,12 @@ public class GravityFlipPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+#if ENABLE_INPUT_SYSTEM
+            // Route rumble to the active controller for tactile feedback.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -40,6 +40,9 @@ using TMPro; // TextMeshPro used for binding label updates
 /// 2036 update: rebinding UI labels now use <see cref="TMP_Text"/> to provide
 /// crisp, resolution-independent text and remove the dependency on legacy
 /// <c>UnityEngine.UI.Text</c> components.
+/// 2040 update: <c>TriggerRumble</c> accepts an optional
+/// <see cref="Gamepad"/> parameter so vibration can target specific devices,
+/// improving support for multi-controller setups.
 /// </summary>
 public static class InputManager
 {
@@ -775,24 +778,32 @@ public static class InputManager
 
 #if ENABLE_INPUT_SYSTEM
     /// <summary>
-    /// Triggers controller rumble using the current gamepad. The effect stops
-    /// automatically after the supplied duration.
+    /// Triggers controller rumble on a specific gamepad. When no device is
+    /// supplied the system falls back to <see cref="Gamepad.current"/>. The
+    /// vibration automatically stops after the supplied duration.
     /// </summary>
     /// <param name="strength">Strength from 0 to 1 for the vibration motors.</param>
     /// <param name="duration">Time in seconds the motors should run.</param>
-    public static void TriggerRumble(float strength, float duration)
+    /// <param name="pad">Optional target controller. <c>null</c> routes the
+    ///     rumble to <see cref="Gamepad.current"/>.</param>
+    public static void TriggerRumble(float strength, float duration, Gamepad pad = null)
     {
         // Respect the player's preference: skip rumble entirely when disabled.
         if (!RumbleEnabled)
             return;
 
+        // Resolve the target controller. When the caller passes null we default
+        // to the system's currently active gamepad so callers can rely on the
+        // original behaviour.
+        pad ??= Gamepad.current;
+
         // Lazily create the coroutine host so hidden GameObjects are only
         // spawned if vibration is actually requested.
-        EnsureRumbleHost();
+        EnsureRumbleHost(pad);
 
         // Abort if no compatible gamepad is connected or the host could not be
         // created (for example, in headless test environments).
-        if (Gamepad.current == null || rumbleHost == null)
+        if (pad == null || rumbleHost == null)
             return;
 
         // Clamp parameters to safe ranges to avoid unexpected behaviour from
@@ -814,7 +825,7 @@ public static class InputManager
 
         // Begin the rumble coroutine which automatically resets after the
         // specified realtime duration.
-        rumbleRoutine = rumbleHost.StartCoroutine(RumbleRoutine(strength, duration));
+        rumbleRoutine = rumbleHost.StartCoroutine(RumbleRoutine(pad, strength, duration));
     }
 
     /// <summary>
@@ -822,11 +833,13 @@ public static class InputManager
     /// coroutines. The host is created on demand when a gamepad is connected,
     /// preventing unused hidden objects in scenes that never request rumble.
     /// </summary>
+    /// <param name="pad">Controller that will receive rumble. A host is only
+    /// created when this parameter is non-null.</param>
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
-    private static void EnsureRumbleHost()
+    private static void EnsureRumbleHost(Gamepad pad)
     {
-        // Skip if a host already exists or no controller is available.
-        if (rumbleHost != null || Gamepad.current == null)
+        // Skip if a host already exists or the supplied controller is missing.
+        if (rumbleHost != null || pad == null)
             return;
 
         // Reuse a surviving host from a previous play session when possible so
@@ -847,13 +860,14 @@ public static class InputManager
         rumbleHost = hostObj.AddComponent<RumbleHost>();
     }
 
-    // Coroutine that applies rumble then resets the motor speeds.
-    private static IEnumerator RumbleRoutine(float strength, float duration)
+    // Coroutine that applies rumble then resets the motor speeds on the
+    // specified controller.
+    private static IEnumerator RumbleRoutine(Gamepad pad, float strength, float duration)
     {
-        Gamepad.current.SetMotorSpeeds(strength, strength);
+        pad.SetMotorSpeeds(strength, strength);
         // Wait in realtime so pausing the game doesn't prolong vibration.
         yield return new WaitForSecondsRealtime(duration);
-        Gamepad.current.SetMotorSpeeds(0f, 0f);
+        pad.SetMotorSpeeds(0f, 0f);
         // Mark the routine as finished so another rumble can start.
         rumbleRoutine = null;
     }

--- a/Assets/Scripts/InvincibilityPowerUp.cs
+++ b/Assets/Scripts/InvincibilityPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Allow targeting the player's gamepad
+#endif
 
 /// <summary>
 /// Provides temporary invulnerability identical to <see cref="PlayerShield"/> but
@@ -46,7 +49,12 @@ public class InvincibilityPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+#if ENABLE_INPUT_SYSTEM
+            // Vibrate the active gamepad to reinforce invulnerability pickup.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
 
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)

--- a/Assets/Scripts/MagnetPowerUp.cs
+++ b/Assets/Scripts/MagnetPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Specify gamepad for rumble
+#endif
 
 /// <summary>
 /// Grants the player a temporary coin magnet effect when collected.
@@ -38,7 +41,12 @@ public class MagnetPowerUp : MonoBehaviour
                 AudioManager.Instance.PlaySound(collectClip);
             }
             // Light rumble to acknowledge the pickup.
+#if ENABLE_INPUT_SYSTEM
+            // Signal activation through the player's current controller.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -6,8 +6,13 @@
 // reference errors when the script is placed on new prefabs.
 // 2029 refactor: Physics forces and velocity changes now occur within
 // FixedUpdate using Time.fixedDeltaTime for frame-rate-independent behaviour.
+// 2040 update: Rumble requests now specify the active gamepad so haptic
+// feedback targets the correct controller in multi-device setups.
 
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Access Gamepad.current for rumble targeting
+#endif
 
 /// <summary>
 /// Handles all player movement including jumping, variable jump height, sliding
@@ -352,8 +357,14 @@ public class PlayerController : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(jumpClip);
             }
-            // Provide haptic feedback so jumps feel responsive.
+            // Provide haptic feedback so jumps feel responsive. When the new
+            // Input System is active we explicitly route rumble to the current
+            // gamepad; otherwise the legacy stub ignores this call.
+#if ENABLE_INPUT_SYSTEM
+            InputManager.TriggerRumble(0.5f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.5f, 0.1f);
+#endif
             if (!isGrounded && jumpsRemaining > 0)
             {
                 jumpsRemaining--;
@@ -464,8 +475,13 @@ public class PlayerController : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(hitClip);
             }
-            // Strong rumble feedback on taking damage.
+            // Strong rumble feedback on taking damage. Target the active
+            // controller when using the new Input System.
+#if ENABLE_INPUT_SYSTEM
+            InputManager.TriggerRumble(1f, 0.3f, Gamepad.current);
+#else
             InputManager.TriggerRumble(1f, 0.3f);
+#endif
             if (GameManager.Instance != null && !GameManager.Instance.IsGameOver())
             {
                 GameManager.Instance.GameOver();

--- a/Assets/Scripts/ShieldPowerUp.cs
+++ b/Assets/Scripts/ShieldPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Needed to pass the active gamepad
+#endif
 
 /// <summary>
 /// Grants the player temporary invulnerability when collected.
@@ -36,7 +39,12 @@ public class ShieldPowerUp : MonoBehaviour
                 AudioManager.Instance.PlaySound(collectClip);
             }
             // Brief vibration feedback on pickup.
+#if ENABLE_INPUT_SYSTEM
+            // Rumble only the current player's controller to confirm shielding.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/SlowMotionPowerUp.cs
+++ b/Assets/Scripts/SlowMotionPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Access Gamepad.current for rumble
+#endif
 
 /// <summary>
 /// Grants a temporary slow motion effect when collected. Time scale is
@@ -35,7 +38,12 @@ public class SlowMotionPowerUp : MonoBehaviour
             {
                 AudioManager.Instance.PlaySound(collectClip);
             }
+#if ENABLE_INPUT_SYSTEM
+            // Pulse the controller of the current player to highlight activation.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Scripts/SpeedBoostPowerUp.cs
+++ b/Assets/Scripts/SpeedBoostPowerUp.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem; // Needed for specifying target gamepad
+#endif
 
 /// <summary>
 /// Grants the player a temporary speed multiplier when collected.
@@ -39,7 +42,12 @@ public class SpeedBoostPowerUp : MonoBehaviour
                 AudioManager.Instance.PlaySound(collectClip);
             }
             // Provide subtle feedback on collection.
+#if ENABLE_INPUT_SYSTEM
+            // Notify the player via their current controller about the speed boost.
+            InputManager.TriggerRumble(0.3f, 0.1f, Gamepad.current);
+#else
             InputManager.TriggerRumble(0.3f, 0.1f);
+#endif
             PooledObject po = GetComponent<PooledObject>();
             if (po != null && po.Pool != null)
             {

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -369,6 +369,42 @@ public class InputManagerTests
     }
 
     /// <summary>
+    /// Supplying a specific <see cref="Gamepad"/> to
+    /// <see cref="InputManager.TriggerRumble"/> should vibrate only that device,
+    /// leaving others untouched. This ensures multiplayer setups can direct
+    /// haptics to the appropriate player.
+    /// </summary>
+    [Test]
+    public void TriggerRumble_TargetsSpecifiedGamepad()
+    {
+        // Create two controllers to mimic multiple players.
+        var padOne = InputSystem.AddDevice<Gamepad>();
+        var padTwo = InputSystem.AddDevice<Gamepad>();
+        InputManager.SetRumbleEnabled(true);
+
+        // Request rumble on the second pad only.
+        InputManager.TriggerRumble(0.1f, 0.01f, padTwo);
+
+        // First pad should remain idle because it was not targeted.
+        float low, high;
+        padOne.GetMotorSpeeds(out low, out high);
+        Assert.AreEqual(0f, low, 0.0001f,
+            "Pad one should not rumble when another pad is specified");
+
+        // Second pad should receive the vibration request.
+        padTwo.GetMotorSpeeds(out low, out high);
+        Assert.Greater(low, 0f,
+            "Pad two should rumble when passed to TriggerRumble");
+
+        // Clean up devices and reset InputManager for later tests.
+        InputManager.Shutdown();
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(InputManager).TypeHandle);
+        InputSystem.RemoveDevice(padOne);
+        InputSystem.RemoveDevice(padTwo);
+    }
+
+    /// <summary>
     /// The rumble host should be created only when rumble is actually requested,
     /// keeping the scene free of hidden objects in projects that never vibrate.
     /// </summary>


### PR DESCRIPTION
## Summary
- let TriggerRumble accept an optional `Gamepad` parameter and default to `Gamepad.current`
- route rumble requests from player and power-ups to the active controller
- add test to ensure rumble only affects the specified gamepad

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test`