### PR TITLE
feat(audio): switch sound effects to addressables

### DIFF
--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -11,12 +11,19 @@
  *
  * 2024 maintenance:
  *   - Added clip caching so sound effects loaded by name are fetched from
- *     disk only once. Cached clips persist for the lifetime of the manager
- *     because the project uses a small audio set. Call <see cref="ClearClipCache"/>
- *     if manual cleanup is required.
- */
+ *     disk only once.
+ *
+ * 2025 maintenance:
+ *   - Switched from Resources.Load to Unity Addressables. Sound effects now
+ *     load asynchronously and their underlying handles are cached and released
+ *     automatically, reducing memory usage in larger projects.
+ *     Call <see cref="ClearClipCache"/> for an explicit cleanup.
+*/
 #endregion
 using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using System.Collections;
 using System.Collections.Generic;
 
 /// <summary>
@@ -37,12 +44,26 @@ public class AudioManager : MonoBehaviour
     public AudioSource musicSourceSecondary;
     public AudioSource effectsSource;
 
-    // Cache storing AudioClips loaded via PlaySound(string). This avoids
-    // repeated Resources.Load calls for frequently used effects. Entries are
-    // retained for the lifetime of the manager; no automatic eviction strategy
-    // is implemented because the sound library is small. Tests or callers can
-    // invoke ClearClipCache() to release references when needed.
-    private readonly Dictionary<string, AudioClip> clipCache = new Dictionary<string, AudioClip>();
+    // Cache storing Addressables handles for sound effects requested via
+    // PlaySound(string). Each entry records the handle and a coroutine used to
+    // release the clip after a period of inactivity. This approach avoids
+    // repeated disk access while still allowing unused clips to be unloaded
+    // automatically to free memory.
+    private readonly Dictionary<string, ClipReference> clipCache = new Dictionary<string, ClipReference>();
+
+    // Duration in seconds that a clip remains in the cache after its last use.
+    // Tests can override this to zero for immediate release or increase it for
+    // longer-lived caching depending on project needs.
+    [Tooltip("Seconds a sound effect stays in cache after playback.")]
+    public float clipReleaseDelay = 5f;
+
+    // Internal record tying an Addressables handle to a coroutine that will
+    // release it after clipReleaseDelay seconds.
+    private class ClipReference
+    {
+        public AsyncOperationHandle<AudioClip> handle;
+        public Coroutine releaseCoroutine;
+    }
 
     // Name of the music clip located under Assets/Audio/Resources.
     public string backgroundMusicName = "Background";
@@ -136,25 +157,44 @@ public class AudioManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Clears all cached sound effect clips. Because clips are cached for the
-    /// lifetime of the manager, this method provides manual eviction when tests
-    /// or gameplay need to reclaim memory.
+    /// Clears all cached sound effect handles. Each handle is released via the
+    /// Addressables system before the cache is emptied. Tests or callers invoke
+    /// this method for an immediate cleanup rather than waiting for the
+    /// automatic timeout.
     /// </summary>
     public void ClearClipCache()
     {
+        foreach (var kvp in clipCache)
+        {
+            if (kvp.Value.releaseCoroutine != null)
+            {
+                StopCoroutine(kvp.Value.releaseCoroutine);
+            }
+            ReleaseHandle(kvp.Value.handle);
+        }
         clipCache.Clear();
     }
 
     /// <summary>
-    /// Loads an AudioClip from the Resources/Audio folder. This indirection
-    /// exists so unit tests can override the loading mechanism without relying
-    /// on actual asset files.
+    /// Initiates an Addressables load for a clip. The default implementation
+    /// simply forwards to <see cref="Addressables.LoadAssetAsync{TObject}(object)"/>
+    /// and returns the handle so callers can monitor or release it. Unit tests
+    /// override this method to inject stub clips without touching the disk.
     /// </summary>
-    /// <param name="clipName">Name of the clip to load.</param>
-    /// <returns>The loaded clip or null if not found.</returns>
-    protected virtual AudioClip LoadClip(string clipName)
+    /// <param name="clipName">Addressable key used to locate the clip.</param>
+    /// <returns>Async handle representing the load request.</returns>
+    protected virtual AsyncOperationHandle<AudioClip> LoadClipHandle(string clipName)
     {
-        return Resources.Load<AudioClip>("Audio/" + clipName);
+        return Addressables.LoadAssetAsync<AudioClip>(clipName);
+    }
+
+    /// <summary>
+    /// Releases an Addressables handle. Exposed as virtual so unit tests can
+    /// track when releases occur without depending on the Addressables runtime.
+    /// </summary>
+    protected virtual void ReleaseHandle(AsyncOperationHandle<AudioClip> handle)
+    {
+        Addressables.Release(handle);
     }
 
     /// <summary>
@@ -172,30 +212,58 @@ public class AudioManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Convenience overload that loads a clip from Resources/Audio by name.
-    /// To reduce disk access, clips are cached after their first load and
-    /// reused for subsequent calls. No automatic eviction is performed because
-    /// the expected number of unique effects is small; call
-    /// <see cref="ClearClipCache"/> if manual cleanup is required.
+    /// Convenience overload that loads a sound effect by addressable key. The
+    /// clip is cached via its <see cref="AsyncOperationHandle"/> so subsequent
+    /// plays do not trigger another load. After <see cref="clipReleaseDelay"/>
+    /// seconds of inactivity the handle is automatically released to reclaim
+    /// memory.
     /// </summary>
-    /// <param name="clipName">Clip located under Resources/Audio.</param>
+    /// <param name="clipName">Addressable key identifying the clip.</param>
     /// <param name="pitch">Optional pitch adjustment passed to PlaySound.</param>
     public void PlaySound(string clipName, float pitch = 1f)
     {
-        if (string.IsNullOrEmpty(clipName) || effectsSource == null) return;
-
-        if (!clipCache.TryGetValue(clipName, out AudioClip clip) || clip == null)
+        if (string.IsNullOrEmpty(clipName) || effectsSource == null)
         {
-            clip = LoadClip(clipName);
-            if (clip != null)
-            {
-                clipCache[clipName] = clip;
-            }
+            return;
         }
 
-        if (clip != null)
+        if (!clipCache.TryGetValue(clipName, out ClipReference reference) ||
+            !reference.handle.IsValid() || reference.handle.Result == null)
         {
-            PlaySound(clip, pitch);
+            // Load clip via Addressables and wait synchronously for completion so
+            // the one-shot can play immediately. In a production game this could
+            // be fully asynchronous with a callback.
+            var handle = LoadClipHandle(clipName);
+            handle.WaitForCompletion();
+            if (handle.Status != AsyncOperationStatus.Succeeded || handle.Result == null)
+            {
+                Debug.LogWarning($"Sound clip '{clipName}' failed to load");
+                return;
+            }
+
+            reference = new ClipReference { handle = handle };
+            clipCache[clipName] = reference;
+        }
+
+        // Play the loaded clip immediately.
+        PlaySound(reference.handle.Result, pitch);
+
+        // Restart the release timer so the clip remains cached while in recent use.
+        if (reference.releaseCoroutine != null)
+        {
+            StopCoroutine(reference.releaseCoroutine);
+        }
+        reference.releaseCoroutine = StartCoroutine(ReleaseAfterDelay(clipName, clipReleaseDelay));
+    }
+
+    // Coroutine that waits the configured delay before releasing a cached clip.
+    private IEnumerator ReleaseAfterDelay(string clipName, float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        if (clipCache.TryGetValue(clipName, out ClipReference reference))
+        {
+            ReleaseHandle(reference.handle);
+            clipCache.Remove(clipName);
         }
     }
 

--- a/Assets/Tests/EditMode/AudioManagerTests.cs
+++ b/Assets/Tests/EditMode/AudioManagerTests.cs
@@ -1,6 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -39,20 +41,28 @@ public class AudioManagerTests
     }
 
     /// <summary>
-    /// AudioManager subclass used to track how many times a clip is loaded.
-    /// The overridden <see cref="AudioManager.LoadClip"/> method returns a
-    /// reusable stub clip and increments a counter for verification.
+    /// AudioManager subclass used to track load and release counts. The
+    /// overridden Addressables hooks return a completed handle containing a
+    /// reusable stub clip so tests do not touch disk.
     /// </summary>
     private class CachingAudioManager : AudioManager
     {
         public int loadCount;
+        public int releaseCount;
         public AudioClip stubClip = AudioClip.Create("stub", 441, 1, 44100, false);
 
-        protected override AudioClip LoadClip(string clipName)
+        protected override AsyncOperationHandle<AudioClip> LoadClipHandle(string clipName)
         {
             loadCount++;
             stubClip.name = clipName;
-            return stubClip;
+            // Create a completed handle containing the stub clip.
+            return Addressables.ResourceManager.CreateCompletedOperation<AudioClip>(stubClip, null);
+        }
+
+        protected override void ReleaseHandle(AsyncOperationHandle<AudioClip> handle)
+        {
+            // Track releases instead of delegating to Addressables.
+            releaseCount++;
         }
     }
 
@@ -141,15 +151,16 @@ public class AudioManagerTests
 
     /// <summary>
     /// Ensures that <see cref="AudioManager.PlaySound(string, float)"/> caches
-    /// loaded clips and reuses them on subsequent calls rather than reloading
-    /// from disk.
+    /// loaded clips and reuses them on subsequent calls until the release
+    /// timeout expires.
     /// </summary>
     [Test]
-    public void PlaySound_ReusesCachedClip()
+    public void PlaySound_CachesClipUntilRelease()
     {
         var obj = new GameObject("am");
         var am = obj.AddComponent<CachingAudioManager>();
         am.effectsSource = obj.AddComponent<AudioSource>();
+        am.clipReleaseDelay = 100f; // Ensure the clip persists in cache.
 
         // Awake is normally called by Unity; invoke manually so the singleton
         // instance and internal fields initialize for the test environment.
@@ -162,12 +173,49 @@ public class AudioManagerTests
         // The overridden loader should have been called only once because the
         // second call retrieves the clip from cache.
         Assert.AreEqual(1, am.loadCount, "Clip should be loaded once and then reused");
+        Assert.AreEqual(0, am.releaseCount, "Clip should not be released while cached");
 
         // Access the private cache via reflection to verify the stored instance.
         var cacheField = typeof(AudioManager).GetField("clipCache", BindingFlags.NonPublic | BindingFlags.Instance);
-        var cache = (Dictionary<string, AudioClip>)cacheField.GetValue(am);
-        Assert.IsTrue(cache.ContainsKey("beep"), "Cache should contain the loaded clip");
-        Assert.AreSame(am.stubClip, cache["beep"], "Cached clip should match the loaded instance");
+        var cache = (System.Collections.IDictionary)cacheField.GetValue(am);
+        Assert.IsTrue(cache.Contains("beep"), "Cache should contain the loaded clip");
+        var entry = cache["beep"]; // ClipReference
+        var handleField = entry.GetType().GetField("handle", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var handle = (AsyncOperationHandle<AudioClip>)handleField.GetValue(entry);
+        Assert.AreSame(am.stubClip, handle.Result, "Cached clip should match the loaded instance");
+
+        Object.DestroyImmediate(obj);
+    }
+
+    /// <summary>
+    /// Confirms that cached clips are released after the configured delay and
+    /// subsequently reloaded when requested again.
+    /// </summary>
+    [UnityTest]
+    public IEnumerator PlaySound_ReleasesAndReloadsClip()
+    {
+        var obj = new GameObject("am");
+        var am = obj.AddComponent<CachingAudioManager>();
+        am.effectsSource = obj.AddComponent<AudioSource>();
+        am.clipReleaseDelay = 0f; // Immediate release for test speed.
+
+        typeof(AudioManager).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(am, null);
+
+        am.PlaySound("beep");
+        // Allow the release coroutine to run.
+        yield return null;
+
+        Assert.AreEqual(1, am.releaseCount, "Clip should be released after delay");
+
+        // Cache should no longer contain the clip.
+        var cacheField = typeof(AudioManager).GetField("clipCache", BindingFlags.NonPublic | BindingFlags.Instance);
+        var cache = (System.Collections.IDictionary)cacheField.GetValue(am);
+        Assert.IsFalse(cache.Contains("beep"), "Cache should be empty after release");
+
+        // Playing again should trigger another load.
+        am.PlaySound("beep");
+        Assert.AreEqual(2, am.loadCount, "Clip should reload after being released");
 
         Object.DestroyImmediate(obj);
     }


### PR DESCRIPTION
## Summary
- load sound effects using Unity Addressables with timed handle cache
- release unused audio handles and document new strategy
- add tests ensuring handles are released and reloaded when needed

## Testing
- `npm test`