### PR TITLE
Warn and recover from invalid saved key bindings

### DIFF
--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -43,6 +43,10 @@ using TMPro; // TextMeshPro used for binding label updates
 /// 2040 update: <c>TriggerRumble</c> accepts an optional
 /// <see cref="Gamepad"/> parameter so vibration can target specific devices,
 /// improving support for multi-controller setups.
+/// 2042 fix: <c>LoadKey</c> now logs a warning through
+/// <see cref="LoggingHelper"/> when a saved key cannot be parsed, ensuring
+/// corrupted preferences visibly fall back to safe defaults instead of failing
+/// silently.
 /// </summary>
 public static class InputManager
 {
@@ -320,16 +324,41 @@ public static class InputManager
 #endif
 
     /// <summary>
-    /// Loads a key binding from PlayerPrefs and falls back to the provided
-    /// default when the stored value cannot be parsed.
+    /// Retrieves a key binding from <see cref="PlayerPrefs"/> and returns the
+    /// provided <paramref name="defaultKey"/> when the stored value is missing
+    /// or invalid.
     /// </summary>
+    /// <param name="pref">Preference key used to locate the saved binding.</param>
+    /// <param name="defaultKey">Fallback key to use when parsing fails.</param>
+    /// <returns>
+    /// The parsed <see cref="KeyCode"/> if the preference contains a valid
+    /// value; otherwise the supplied <paramref name="defaultKey"/>.
+    /// </returns>
+    /// <remarks>
+    /// If parsing fails, the method logs a warning via
+    /// <see cref="LoggingHelper.LogWarning"/> to aid in diagnosing corrupted or
+    /// tampered preference data.
+    /// </remarks>
     private static KeyCode LoadKey(string pref, KeyCode defaultKey)
     {
+        // Obtain the saved string, defaulting to the provided key when no entry
+        // exists. Using ToString here ensures consistency with how bindings are
+        // saved by Set*Key helpers elsewhere in this class.
         string saved = PlayerPrefs.GetString(pref, defaultKey.ToString());
+
+        // Attempt to convert the persisted string back into a KeyCode enum. The
+        // Enum.TryParse call returns false when the data is corrupt or has been
+        // manually edited to an unsupported value.
         if (System.Enum.TryParse(saved, out KeyCode key))
         {
-            return key;
+            return key; // Successfully parsed; use the stored binding.
         }
+
+        // Emit a warning so developers can spot the invalid preference during
+        // testing. The message includes the preference key and invalid value for
+        // easier debugging. The default key is returned to keep input usable.
+        LoggingHelper.LogWarning(
+            $"Invalid KeyCode '{saved}' for preference '{pref}'. Reverting to default '{defaultKey}'.");
         return defaultKey;
     }
 

--- a/Assets/Tests/EditMode/InputManagerKeyLoadTests.cs
+++ b/Assets/Tests/EditMode/InputManagerKeyLoadTests.cs
@@ -1,0 +1,59 @@
+// InputManagerKeyLoadTests.cs
+// -----------------------------------------------------------------------------
+// Validates the behavior of InputManager's legacy PlayerPrefs key loading
+// functionality. The tests simulate corrupted preference data to ensure the
+// manager warns via LoggingHelper and safely falls back to default bindings.
+// Run via the Unity Test Runner in edit mode.
+// -----------------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// Exercises the <see cref="InputManager"/> key-loading path to confirm that
+/// invalid PlayerPrefs entries trigger a warning and revert to expected
+/// defaults. This guards against silent failures where tampered or corrupted
+/// preferences could leave controls unresponsive without any developer
+/// visibility.
+/// </summary>
+public class InputManagerKeyLoadTests
+{
+    /// <summary>
+    /// When a saved key cannot be parsed into a <see cref="KeyCode"/>, the
+    /// manager should emit a warning and fall back to the documented default.
+    /// </summary>
+    [Test]
+    public void LoadKey_InvalidValue_LogsWarningAndRevertsToDefault()
+    {
+        // Ensure warnings are not suppressed so LogAssert can intercept them.
+        LoggingHelper.VerboseEnabled = true;
+
+        // Seed an invalid value to simulate corrupt or manually edited prefs.
+        PlayerPrefs.SetString("JumpKey", "NotAKey");
+
+        // The next initialization of InputManager should warn about the bad
+        // value and then restore the default key binding.
+        LogAssert.Expect(
+            LogType.Warning,
+            "Invalid KeyCode 'NotAKey' for preference 'JumpKey'. Reverting to default 'Space'.");
+
+        // Reset any existing state and rerun the static constructor so LoadKey
+        // executes with the corrupt preference in place.
+        InputManager.Shutdown();
+        RuntimeHelpers.RunClassConstructor(typeof(InputManager).TypeHandle);
+
+        // After initialization, the JumpKey property should hold the default
+        // binding since the saved value was rejected.
+        Assert.AreEqual(
+            KeyCode.Space,
+            InputManager.JumpKey,
+            "JumpKey should revert to Space when an invalid key is saved");
+
+        // Clean up to avoid polluting other tests.
+        PlayerPrefs.DeleteKey("JumpKey");
+        InputManager.Shutdown();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Warn via LoggingHelper when PlayerPrefs key strings can't be parsed and fall back to defaults
- Document LoadKey's warning behavior
- Test that corrupt saved key bindings log a warning and restore default controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8daf0e6f48321993fb6d127672761