### PR TITLE
feat: add detailed leaderboard error handling

### DIFF
--- a/Assets/Resources/Localization/en.json
+++ b/Assets/Resources/Localization/en.json
@@ -22,6 +22,11 @@
     {"key": "ach_daily_complete_desc", "value": "Complete a daily challenge."},
     {"key": "leaderboard_entry_format", "value": "{0}. {1} - {2}"},
     {"key": "leaderboard_local_player", "value": "Local"},
-    {"key": "achievement_unlocked", "value": " (Unlocked)"}
+    {"key": "achievement_unlocked", "value": " (Unlocked)"},
+    {"key": "leaderboard_error_network", "value": "Network unreachable."},
+    {"key": "leaderboard_error_http", "value": "Server returned an error."},
+    {"key": "leaderboard_error_certificate", "value": "Certificate validation failed."},
+    {"key": "leaderboard_error_timeout", "value": "Request timed out."},
+    {"key": "leaderboard_error_unknown", "value": "Failed to load leaderboard."}
   ]
 }

--- a/Assets/Resources/Localization/es.json
+++ b/Assets/Resources/Localization/es.json
@@ -22,6 +22,11 @@
     {"key": "ach_daily_complete_desc", "value": "Completa un desafío diario."},
     {"key": "leaderboard_entry_format", "value": "{0}. {1} - {2}"},
     {"key": "leaderboard_local_player", "value": "Local ES"},
-    {"key": "achievement_unlocked", "value": " (Desbloqueado)"}
+    {"key": "achievement_unlocked", "value": " (Desbloqueado)"},
+    {"key": "leaderboard_error_network", "value": "Red inaccesible."},
+    {"key": "leaderboard_error_http", "value": "El servidor devolvió un error."},
+    {"key": "leaderboard_error_certificate", "value": "Falló la validación del certificado."},
+    {"key": "leaderboard_error_timeout", "value": "La solicitud excedió el tiempo."},
+    {"key": "leaderboard_error_unknown", "value": "No se pudo cargar la tabla de clasificación."}
   ]
 }

--- a/Assets/Scripts/LeaderboardClient.cs
+++ b/Assets/Scripts/LeaderboardClient.cs
@@ -13,7 +13,10 @@ using UnityEngine.Networking;
 // exponential backoff, and richer error reporting so callers can distinguish
 // between client and server failures. The latest update exposes explicit
 // success flags from upload and download operations so the UI can present
-// meaningful error messages when network communication fails.
+// meaningful error messages when network communication fails. In this revision
+// error handling has been expanded further with explicit error codes covering
+// network, HTTP, certificate and timeout issues so the UI can surface
+// localized explanations for each failure mode.
 
 /// <summary>
 /// Client for a simple REST-based leaderboard service used when Steamworks
@@ -84,6 +87,22 @@ public class LeaderboardClient : MonoBehaviour
     }
 
     /// <summary>
+    /// Enumerates specific error categories surfaced from HTTP requests. Using
+    /// explicit codes instead of booleans allows UI elements to present more
+    /// descriptive messages to the player and enables tests to verify that the
+    /// correct failure mode was detected.
+    /// </summary>
+    public enum ErrorCode
+    {
+        None = 0,
+        NetworkError,
+        HttpError,
+        CertificateError,
+        Timeout,
+        Unknown
+    }
+
+    /// <summary>
     /// Uploads <paramref name="score"/> associated with <see cref="playerName"/>.
     /// The request body is JSON of the form {"name":"Player","score":100}.
     /// A callback reports whether the upload ultimately succeeded so callers
@@ -91,7 +110,7 @@ public class LeaderboardClient : MonoBehaviour
     /// </summary>
     /// <param name="score">Score value to submit.</param>
     /// <param name="onComplete">Optional callback receiving a success flag.</param>
-    public IEnumerator UploadScore(int score, System.Action<bool> onComplete = null)
+    public IEnumerator UploadScore(int score, System.Action<bool, ErrorCode> onComplete = null)
     {
         // Ensure serviceUrl is configured and uses HTTPS before attempting
         // to communicate with the leaderboard. Failing to validate here would
@@ -113,6 +132,7 @@ public class LeaderboardClient : MonoBehaviour
         const int maxRetries = 3;
         int attempt = 0;
         bool success = false;
+        ErrorCode lastError = ErrorCode.None; // Tracks final error for UI reporting
         while (attempt < maxRetries && !success)
         {
             using (UnityWebRequest req = new UnityWebRequest(url, "POST"))
@@ -123,7 +143,10 @@ public class LeaderboardClient : MonoBehaviour
                 req.SetRequestHeader("Content-Type", "application/json");
                 req.timeout = RequestTimeoutSeconds; // Seconds before the request automatically times out.
 
-                yield return SendWebRequest(req, (ok, _unused) => success = ok);
+                // Send the request and capture both the success flag and any
+                // associated error code so callers can surface a meaningful
+                // message to the player.
+                yield return SendWebRequest(req, (ok, _unused, code) => { success = ok; lastError = code; });
             }
 
             // Exponential backoff: 1s, 2s, 4s delays between attempts.
@@ -138,10 +161,14 @@ public class LeaderboardClient : MonoBehaviour
         if (!success)
         {
             Debug.LogWarning("Failed to upload score to leaderboard");
+            // Surface the specific error to the UI so a localized message can
+            // be displayed instead of silently failing.
+            UIManager.Instance?.ShowLeaderboardError(lastError);
         }
-        // Notify caller of the final outcome. This enables UI elements to
-        // display error messages or retry options.
-        onComplete?.Invoke(success);
+
+        // Notify caller of the final outcome along with the error code. This
+        // enables external UI to present retry prompts or other feedback.
+        onComplete?.Invoke(success, lastError);
 
         // Hide the network activity spinner now that the request has finished.
         UIManager.Instance?.HideNetworkSpinner();
@@ -155,10 +182,11 @@ public class LeaderboardClient : MonoBehaviour
     /// succeeded so callers can present error messages.
     /// </summary>
     /// <param name="callback">Invoked with the retrieved scores and a success flag.</param>
-    public virtual IEnumerator GetTopScores(System.Action<List<ScoreEntry>, bool> callback)
+    public virtual IEnumerator GetTopScores(System.Action<List<ScoreEntry>, bool, ErrorCode> callback)
     {
         List<ScoreEntry> result = null; // Final list of scores to return
         bool success = false;           // Tracks whether the remote request succeeded
+        ErrorCode error = ErrorCode.None; // Detailed error category surfaced to UI
 
         // Validate serviceUrl to enforce secure communication. If invalid,
         // immediately return the local high score without issuing any web
@@ -178,7 +206,8 @@ public class LeaderboardClient : MonoBehaviour
                 {
                     req.downloadHandler = new DownloadHandlerBuffer();
                     req.timeout = RequestTimeoutSeconds; // Seconds before the request automatically times out.
-                    yield return SendWebRequest(req, (ok, data) => { success = ok; text = data; });
+                    // Capture both success and any error code for the UI.
+                    yield return SendWebRequest(req, (ok, data, code) => { success = ok; text = data; error = code; });
                 }
 
                 if (!success && ++attempt < maxRetries)
@@ -207,39 +236,112 @@ public class LeaderboardClient : MonoBehaviour
             string name = LocalizationManager.Get("leaderboard_local_player");
             result = new List<ScoreEntry> { new ScoreEntry { name = name, score = local } };
             success = false;
+            if (error == ErrorCode.None)
+            {
+                // If no explicit error was recorded, categorize the fallback as
+                // a generic network issue so the UI can communicate that
+                // scores were not retrieved from the server.
+                error = ErrorCode.Unknown;
+            }
         }
 
         // Callback receives both the scores to display and whether they came
         // from the remote service (true) or a local fallback (false).
-        callback?.Invoke(result, success);
+        callback?.Invoke(result, success, error);
     }
 
     /// <summary>
     /// Issues the web request and invokes the callback with the outcome.
     /// Tests override this method to provide fake responses.
     /// </summary>
-    protected virtual IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> callback)
+    protected virtual IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string, ErrorCode> callback)
     {
-        string text = null;
-        bool success = false;
+        string text = null;              // Response body when successful
+        bool success = false;            // True when the request completes without errors
+        ErrorCode code = ErrorCode.None; // Categorized error returned to the caller
+
         try
         {
             yield return req.SendWebRequest();
-            if (req.result == UnityWebRequest.Result.Success)
+
+#if UNITY_2020_2_OR_NEWER
+            // Modern Unity versions expose a consolidated result enum so we
+            // inspect it first. Older versions fall back to the legacy
+            // isNetworkError/isHttpError properties handled below.
+            switch (req.result)
+            {
+                case UnityWebRequest.Result.Success:
+                    text = req.downloadHandler.text;
+                    success = true;
+                    break;
+                case UnityWebRequest.Result.ConnectionError:
+                    // Distinguish timeouts and certificate problems where possible.
+                    if (req.error != null && req.error.ToLower().Contains("timed out"))
+                    {
+                        code = ErrorCode.Timeout;
+                    }
+                    else if (req.error != null && req.error.ToLower().Contains("certificate"))
+                    {
+                        code = ErrorCode.CertificateError;
+                    }
+                    else
+                    {
+                        code = ErrorCode.NetworkError;
+                    }
+                    break;
+                case UnityWebRequest.Result.ProtocolError:
+                    code = ErrorCode.HttpError;
+                    break;
+                default:
+                    code = ErrorCode.Unknown;
+                    break;
+            }
+#else
+            if (req.isNetworkError)
+            {
+                if (req.error != null && req.error.ToLower().Contains("timed out"))
+                {
+                    code = ErrorCode.Timeout;
+                }
+                else if (req.error != null && req.error.ToLower().Contains("certificate"))
+                {
+                    code = ErrorCode.CertificateError;
+                }
+                else
+                {
+                    code = ErrorCode.NetworkError;
+                }
+            }
+            else if (req.isHttpError)
+            {
+                code = ErrorCode.HttpError;
+            }
+            else
             {
                 text = req.downloadHandler.text;
                 success = true;
             }
-            else
+#endif
+
+            // Provide additional log context for HTTP failures so developers can
+            // differentiate client versus server-side issues during debugging.
+            if (!success)
             {
-                long code = req.responseCode;
-                if (code >= 400 && code < 500)
+                long status = req.responseCode;
+                if (code == ErrorCode.HttpError)
                 {
-                    Debug.LogWarning($"Client error {code} during leaderboard request: {req.error}");
-                }
-                else if (code >= 500)
-                {
-                    Debug.LogWarning($"Server error {code} during leaderboard request: {req.error}");
+                    if (status >= 400 && status < 500)
+                    {
+                        Debug.LogWarning($"Client error {status} during leaderboard request: {req.error}");
+                    }
+                    else if (status >= 500)
+                    {
+                        Debug.LogWarning($"Server error {status} during leaderboard request: {req.error}");
+                    }
+                    else
+                    {
+                        Debug.LogWarning("Leaderboard request failed: " + req.error);
+                    }
                 }
                 else
                 {
@@ -249,9 +351,11 @@ public class LeaderboardClient : MonoBehaviour
         }
         catch (System.Exception ex)
         {
+            code = ErrorCode.NetworkError;
             Debug.LogWarning("Leaderboard request failed: " + ex.Message);
         }
-        callback?.Invoke(success, text);
+
+        callback?.Invoke(success, text, code);
     }
 
     // Converts a raw JSON array into a list of score entries.

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -42,6 +42,10 @@
 // non-blocking on slower devices. The asynchronous coroutine logs a warning if
 // the expected prefab cannot be found, preserving previous error reporting.
 // -----------------------------------------------------------------------------
+// 2052 update summary
+// Leaderboard operations now expose detailed error codes that map to localized
+// messages, ensuring players see a clear explanation when uploads or downloads
+// fail.
 
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -510,7 +514,7 @@ public class UIManager : MonoBehaviour
     // Helper to format and display leaderboard entries in the panel.
     // Marked public so unit tests and other systems can invoke the formatting
     // logic directly without relying on coroutines.
-    public void DisplayScores(List<LeaderboardClient.ScoreEntry> scores, bool success)
+    public void DisplayScores(List<LeaderboardClient.ScoreEntry> scores, bool success, LeaderboardClient.ErrorCode error = LeaderboardClient.ErrorCode.Unknown)
     {
         if (leaderboardText == null)
         {
@@ -523,12 +527,7 @@ public class UIManager : MonoBehaviour
         // fallback otherwise.
         if (!success)
         {
-            string msg = LocalizationManager.Get("leaderboard_error");
-            if (msg == "leaderboard_error")
-            {
-                msg = "Failed to load leaderboard.";
-            }
-            leaderboardText.text = msg;
+            ShowLeaderboardError(error);
             return;
         }
 
@@ -544,6 +543,67 @@ public class UIManager : MonoBehaviour
             }
             leaderboardText.text = sb.ToString();
         }
+    }
+
+    /// <summary>
+    /// Shows a localized error message in the leaderboard text field based on
+    /// the provided error code. This centralizes mapping of codes to
+    /// human‑readable strings so both upload and download operations present
+    /// consistent messaging.
+    /// </summary>
+    public void ShowLeaderboardError(LeaderboardClient.ErrorCode code)
+    {
+        if (leaderboardText == null)
+        {
+            return;
+        }
+
+        string key;
+        switch (code)
+        {
+            case LeaderboardClient.ErrorCode.CertificateError:
+                key = "leaderboard_error_certificate";
+                break;
+            case LeaderboardClient.ErrorCode.HttpError:
+                key = "leaderboard_error_http";
+                break;
+            case LeaderboardClient.ErrorCode.NetworkError:
+                key = "leaderboard_error_network";
+                break;
+            case LeaderboardClient.ErrorCode.Timeout:
+                key = "leaderboard_error_timeout";
+                break;
+            default:
+                key = "leaderboard_error_unknown";
+                break;
+        }
+
+        string msg = LocalizationManager.Get(key);
+        if (msg == key)
+        {
+            // Fallback English strings when localization is missing to ensure
+            // the player still receives useful feedback.
+            switch (code)
+            {
+                case LeaderboardClient.ErrorCode.CertificateError:
+                    msg = "Certificate validation failed.";
+                    break;
+                case LeaderboardClient.ErrorCode.HttpError:
+                    msg = "Server returned an error.";
+                    break;
+                case LeaderboardClient.ErrorCode.NetworkError:
+                    msg = "Network unreachable.";
+                    break;
+                case LeaderboardClient.ErrorCode.Timeout:
+                    msg = "Request timed out.";
+                    break;
+                default:
+                    msg = "Failed to load leaderboard.";
+                    break;
+            }
+        }
+
+        leaderboardText.text = msg;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/LeaderboardClientIntegrationTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientIntegrationTests.cs
@@ -1,0 +1,94 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Networking;
+using TMPro;
+using System.Collections;
+
+/// <summary>
+/// Integration-style tests exercising <see cref="LeaderboardClient.SendWebRequest"/>
+/// against real <see cref="UnityWebRequest"/> instances to verify that specific
+/// failure modes surface the correct error codes and that
+/// <see cref="UIManager.ShowLeaderboardError"/> converts those codes into
+/// readable messages for the player.
+/// </summary>
+public class LeaderboardClientIntegrationTests
+{
+    /// <summary>
+    /// Helper client exposing the protected <see cref="LeaderboardClient.SendWebRequest"/>
+    /// so tests can drive it directly.
+    /// </summary>
+    private class PublicClient : LeaderboardClient
+    {
+        public IEnumerator Invoke(UnityWebRequest req, System.Action<bool, string, LeaderboardClient.ErrorCode> cb)
+        {
+            return SendWebRequest(req, cb);
+        }
+    }
+
+    /// <summary>
+    /// Certificate handler that deliberately fails validation to simulate TLS
+    /// problems such as expired or self‑signed certificates.
+    /// </summary>
+    private class RejectingCertificateHandler : CertificateHandler
+    {
+        protected override bool ValidateCertificate(byte[] certificateData)
+        {
+            return false;
+        }
+    }
+
+    [Test]
+    public void SendWebRequest_ReportsCertificateError()
+    {
+        var go = new GameObject("lbCert");
+        var client = go.AddComponent<PublicClient>();
+        var req = UnityWebRequest.Get("https://www.example.com");
+        req.certificateHandler = new RejectingCertificateHandler();
+
+        LeaderboardClient.ErrorCode err = LeaderboardClient.ErrorCode.None;
+        var routine = client.Invoke(req, (ok, _text, code) => err = code);
+        while (routine.MoveNext()) { }
+        Assert.AreEqual(LeaderboardClient.ErrorCode.CertificateError, err);
+
+        // Verify UI displays the expected message for this error category.
+        var uiObj = new GameObject("ui");
+        var ui = uiObj.AddComponent<UIManager>();
+        var textObj = new GameObject("txt");
+        var text = textObj.AddComponent<TextMeshProUGUI>();
+        ui.leaderboardText = text;
+        ui.ShowLeaderboardError(err);
+        Assert.AreEqual("Certificate validation failed.", text.text);
+
+        Object.DestroyImmediate(textObj);
+        Object.DestroyImmediate(uiObj);
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void SendWebRequest_ReportsTimeoutError()
+    {
+        var go = new GameObject("lbTimeout");
+        var client = go.AddComponent<PublicClient>();
+        // Use an unroutable IP to trigger a timeout quickly.
+        var req = UnityWebRequest.Get("http://10.255.255.1");
+        req.timeout = 1; // seconds
+
+        LeaderboardClient.ErrorCode err = LeaderboardClient.ErrorCode.None;
+        var routine = client.Invoke(req, (ok, _text, code) => err = code);
+        while (routine.MoveNext()) { }
+        Assert.AreEqual(LeaderboardClient.ErrorCode.Timeout, err);
+
+        // UI should present a friendly timeout message.
+        var uiObj = new GameObject("ui2");
+        var ui = uiObj.AddComponent<UIManager>();
+        var textObj = new GameObject("txt2");
+        var text = textObj.AddComponent<TextMeshProUGUI>();
+        ui.leaderboardText = text;
+        ui.ShowLeaderboardError(err);
+        Assert.AreEqual("Request timed out.", text.text);
+
+        Object.DestroyImmediate(textObj);
+        Object.DestroyImmediate(uiObj);
+        Object.DestroyImmediate(go);
+    }
+}

--- a/Assets/Tests/EditMode/LeaderboardClientTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientTests.cs
@@ -20,10 +20,11 @@ public class LeaderboardClientTests
         public bool succeed;
         public string payload;
 
-        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> cb)
+        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string, LeaderboardClient.ErrorCode> cb)
         {
             sentRequest = req;
-            cb?.Invoke(succeed, payload);
+            var code = succeed ? LeaderboardClient.ErrorCode.None : LeaderboardClient.ErrorCode.NetworkError;
+            cb?.Invoke(succeed, payload, code);
             yield break;
         }
     }
@@ -34,7 +35,7 @@ public class LeaderboardClientTests
     /// </summary>
     private class PublicClient : LeaderboardClient
     {
-        public IEnumerator InvokeSend(UnityWebRequest req, System.Action<bool, string> cb)
+        public IEnumerator InvokeSend(UnityWebRequest req, System.Action<bool, string, LeaderboardClient.ErrorCode> cb)
         {
             return SendWebRequest(req, cb);
         }
@@ -50,12 +51,13 @@ public class LeaderboardClientTests
         public int succeedOn = int.MaxValue; // Attempt index (1-based) when request should succeed
         public int lastTimeout;
 
-        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> cb)
+        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string, LeaderboardClient.ErrorCode> cb)
         {
             calls++;
             lastTimeout = req.timeout;
             bool ok = calls == succeedOn;
-            cb?.Invoke(ok, null);
+            var code = ok ? LeaderboardClient.ErrorCode.None : LeaderboardClient.ErrorCode.NetworkError;
+            cb?.Invoke(ok, null, code);
             yield break;
         }
     }
@@ -66,10 +68,10 @@ public class LeaderboardClientTests
     /// </summary>
     private class SpinnerClient : LeaderboardClient
     {
-        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string> cb)
+        protected override IEnumerator SendWebRequest(UnityWebRequest req, System.Action<bool, string, LeaderboardClient.ErrorCode> cb)
         {
             yield return null; // simulate an async web call
-            cb?.Invoke(true, "[]");
+            cb?.Invoke(true, "[]", LeaderboardClient.ErrorCode.None);
         }
     }
 
@@ -104,7 +106,7 @@ public class LeaderboardClientTests
 
         List<LeaderboardClient.ScoreEntry> result = null;
         bool success = true;
-        var routine = client.GetTopScores((list, ok) => { result = list; success = ok; });
+        var routine = client.GetTopScores((list, ok, _err) => { result = list; success = ok; });
         while (routine.MoveNext()) { }
 
         Assert.IsNotNull(result);
@@ -135,7 +137,7 @@ public class LeaderboardClientTests
         LocalizationManager.SetLanguage("es");
         List<LeaderboardClient.ScoreEntry> result = null;
         bool success = true;
-        var routine = client.GetTopScores((list, ok) => { result = list; success = ok; });
+        var routine = client.GetTopScores((list, ok, _err) => { result = list; success = ok; });
         while (routine.MoveNext()) { }
 
         Assert.AreEqual("Local ES", result[0].name);
@@ -159,7 +161,7 @@ public class LeaderboardClientTests
 
         List<LeaderboardClient.ScoreEntry> result = null;
         bool success = false;
-        var routine = client.GetTopScores((list, ok) => { result = list; success = ok; });
+        var routine = client.GetTopScores((list, ok, _err) => { result = list; success = ok; });
         while (routine.MoveNext()) { }
 
         Assert.IsTrue(success, "Callback should report success when request completes");
@@ -206,7 +208,7 @@ public class LeaderboardClientTests
         client.succeedOn = 2; // Fail first attempt, succeed on second
         bool result = false;
 
-        var routine = client.UploadScore(10, ok => result = ok);
+        var routine = client.UploadScore(10, (ok, _err) => result = ok);
         while (routine.MoveNext()) { }
 
         Assert.AreEqual(2, client.calls, "Upload should retry once before succeeding");
@@ -230,14 +232,14 @@ public class LeaderboardClientTests
         // Simulate successful upload
         client.succeed = true;
         bool success = false;
-        var routine = client.UploadScore(1, ok => success = ok);
+        var routine = client.UploadScore(1, (ok, _err) => success = ok);
         while (routine.MoveNext()) { }
         Assert.IsTrue(success, "Callback should report success when request succeeds");
 
         // Simulate failure
         client.succeed = false;
         success = true;
-        routine = client.UploadScore(1, ok => success = ok);
+        routine = client.UploadScore(1, (ok, _err) => success = ok);
         while (routine.MoveNext()) { }
         Assert.IsFalse(success, "Callback should report failure when request fails");
 
@@ -301,7 +303,11 @@ public class LeaderboardClientTests
         // Expect a log message mentioning a client error (4xx)
         LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("Client error 404"));
 
-        var routine = client.InvokeSend(req, (ok, _text) => Assert.IsFalse(ok));
+        var routine = client.InvokeSend(req, (ok, _text, err) =>
+        {
+            Assert.IsFalse(ok);
+            Assert.AreEqual(LeaderboardClient.ErrorCode.HttpError, err);
+        });
         while (routine.MoveNext()) { }
 
         Object.DestroyImmediate(go);
@@ -325,7 +331,11 @@ public class LeaderboardClientTests
 
         LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("Server error 500"));
 
-        routine = client.InvokeSend(req, (ok, _text) => Assert.IsFalse(ok));
+        routine = client.InvokeSend(req, (ok, _text, err) =>
+        {
+            Assert.IsFalse(ok);
+            Assert.AreEqual(LeaderboardClient.ErrorCode.HttpError, err);
+        });
         while (routine.MoveNext()) { }
 
         Object.DestroyImmediate(go);

--- a/Assets/Tests/EditMode/UIManagerTests.cs
+++ b/Assets/Tests/EditMode/UIManagerTests.cs
@@ -28,11 +28,11 @@ public class UIManagerTests
         var text = textObj.AddComponent<TextMeshProUGUI>();
         ui.leaderboardText = text;
 
-        // Simulate a failed leaderboard retrieval.
-        ui.DisplayScores(null, false);
+        // Simulate a failed leaderboard retrieval due to a network issue.
+        ui.DisplayScores(null, false, LeaderboardClient.ErrorCode.NetworkError);
 
         // The text should now contain the human readable error string.
-        Assert.AreEqual("Failed to load leaderboard.", text.text);
+        Assert.AreEqual("Network unreachable.", text.text);
 
         Object.DestroyImmediate(textObj);
         Object.DestroyImmediate(uiObj);


### PR DESCRIPTION
## Summary
- add error code enum and inspect UnityWebRequest network, HTTP, certificate, and timeout failures
- surface error codes to UI with localized messages
- cover certificate and timeout scenarios in new integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8de0f7ebc83219d4e9ae79ab14a9e