### PR TITLE
docs: remove node tooling and add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to Cave-Runner
+
+This document outlines guidelines for contributing to the Cave-Runner Unity project. The repository intentionally avoids Node.js
+and npm scripts; development relies solely on the Unity editor and its command-line interface.
+
+## Workflow
+- Fork the repository and create your feature branch from `main`.
+- Make changes within the Unity project and include explanatory comments where relevant.
+- Run the EditMode tests through the Unity Test Runner or via the `Unity -batchmode` command.
+- Submit a pull request describing your changes.
+
+## Testing
+Run the project's EditMode tests using Unity. The following command demonstrates the required arguments:
+
+```bash
+Unity -batchmode -projectPath <path> -runTests -testPlatform editmode \
+  -testResults Results.xml -logFile test.log -quit
+```
+
+The command writes a detailed log and XML results file, both of which should be reviewed before opening a pull request.
+
+## Code Style
+- Use descriptive names for classes and variables.
+- Provide inline comments and summary headers explaining the purpose of each script.
+- Validate inputs and raise clear errors for unexpected states.
+
+Following these conventions keeps the project maintainable and understandable for all contributors.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Key files include:
 - **Whitepaper.md** – in-depth design paper analyzing the event-driven
   architecture, spawn algorithms, and proposed areas of future research.
 
+## Tooling
+
+This Unity project intentionally avoids Node.js and related npm tooling. The
+previous placeholder `package.json` has been removed so contributors can focus
+solely on the Unity editor and command-line interface.
+
+For contribution guidelines and testing instructions, see
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## Getting Started
 1. Install **Unity 2022.3 LTS** or newer using Unity Hub.
 2. Clone this repository and open it with Unity.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "cave-runner",
-  "version": "1.0.0",
-  "description": "Unity game project",
-  "scripts": {
-    "test": "echo 'No tests specified'"
-  }
-}


### PR DESCRIPTION
## Summary
- remove placeholder `package.json` since project relies only on Unity tooling
- add Tooling section and link to contribution guide
- introduce `CONTRIBUTING.md` with workflow and test instructions

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found: Unity)*