### PR TITLE
Ensure rumble host initializes after scene load

### DIFF
--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -49,6 +49,10 @@ using TMPro; // TextMeshPro used for binding label updates
 /// <see cref="LoggingHelper"/> when a saved key cannot be parsed, ensuring
 /// corrupted preferences visibly fall back to safe defaults instead of failing
 /// silently.
+/// 2045 fix: rumble host initialization split into a parameterless
+/// <c>InitRumbleHost</c> wrapper so the runtime initialization attribute can be
+/// used while still allowing callers to specify a <see cref="Gamepad"/>
+/// explicitly.
 /// </summary>
 public static class InputManager
 {
@@ -829,7 +833,8 @@ public static class InputManager
         pad ??= Gamepad.current;
 
         // Lazily create the coroutine host so hidden GameObjects are only
-        // spawned if vibration is actually requested.
+        // spawned if vibration is actually requested. InitRumbleHost performs
+        // the same step at scene load for the current controller.
         EnsureRumbleHost(pad);
 
         // Abort if no compatible gamepad is connected or the host could not be
@@ -860,13 +865,28 @@ public static class InputManager
     }
 
     /// <summary>
+    /// Wrapper invoked automatically by Unity after each scene load. The
+    /// runtime initialization attribute requires a parameterless method, so this
+    /// helper simply forwards to <see cref="EnsureRumbleHost(Gamepad)"/> using
+    /// the currently active controller.
+    /// </summary>
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void InitRumbleHost()
+    {
+        // Delegate to the core creation routine. If no controller is connected,
+        // the host is intentionally not created.
+        EnsureRumbleHost(Gamepad.current);
+    }
+
+    /// <summary>
     /// Ensures a persistent <see cref="RumbleHost"/> exists to run rumble
-    /// coroutines. The host is created on demand when a gamepad is connected,
-    /// preventing unused hidden objects in scenes that never request rumble.
+    /// coroutines. Called by <see cref="InitRumbleHost"/> after each scene load
+    /// and by <see cref="TriggerRumble"/> when rumble is requested. The host is
+    /// created on demand only when a gamepad is connected, preventing unused
+    /// hidden objects in scenes that never request rumble.
     /// </summary>
     /// <param name="pad">Controller that will receive rumble. A host is only
     /// created when this parameter is non-null.</param>
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
     private static void EnsureRumbleHost(Gamepad pad)
     {
         // Skip if a host already exists or the supplied controller is missing.

--- a/Assets/Tests/EditMode/InputManagerTests.cs
+++ b/Assets/Tests/EditMode/InputManagerTests.cs
@@ -434,5 +434,41 @@ public class InputManagerTests
 
         InputSystem.RemoveDevice(pad);
     }
+
+    /// <summary>
+    /// When a gamepad is present at scene load time the attributed
+    /// <see cref="InputManager"/> initializer should automatically spawn the
+    /// rumble host so vibration is available without an explicit rumble request.
+    /// This test invokes the initializer via reflection to mimic Unity's
+    /// runtime behaviour and confirms the host object exists afterward.
+    /// </summary>
+    [Test]
+    public void RumbleHostCreated_AfterSceneLoad()
+    {
+        // Start from a clean slate: remove any lingering host and reset the
+        // InputManager state so the initializer runs as it would in a new
+        // session.
+        var existingHost = GameObject.Find("InputManagerRumbleHost");
+        if (existingHost != null)
+            Object.DestroyImmediate(existingHost);
+        InputManager.Shutdown();
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+            typeof(InputManager).TypeHandle);
+
+        // Provide a controller so the initialization routine has a device to
+        // attach the host to.
+        var pad = InputSystem.AddDevice<Gamepad>();
+
+        // InitRumbleHost is private and normally invoked by Unity after scene
+        // load. Reflection allows the test to simulate that callback.
+        var method = typeof(InputManager).GetMethod(
+            "InitRumbleHost", BindingFlags.NonPublic | BindingFlags.Static);
+        method.Invoke(null, null);
+
+        Assert.IsNotNull(GameObject.Find("InputManagerRumbleHost"),
+            "Rumble host should exist after InitRumbleHost is invoked");
+
+        InputSystem.RemoveDevice(pad);
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- Split rumble host setup into InitRumbleHost wrapper invoked after scene load
- Keep EnsureRumbleHost as internal helper accepting a Gamepad parameter
- Add edit-mode test validating rumble host creation after scene load

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ebeb4c0c8321bb3e68b80fd8f275