### PR TITLE
Route SteamManager errors through LoggingHelper

### DIFF
--- a/Assets/Scripts/SteamManager.cs
+++ b/Assets/Scripts/SteamManager.cs
@@ -1,3 +1,11 @@
+// SteamManager.cs
+// -----------------------------------------------------------------------------
+// Manages interactions with the Steamworks API including achievements, cloud
+// saves and leaderboard submissions. This revision funnels all Unity logging
+// through LoggingHelper to centralize output and simplify testing of failure
+// scenarios.
+// -----------------------------------------------------------------------------
+
 using UnityEngine;
 #if UNITY_STANDALONE
 using Steamworks;
@@ -69,7 +77,9 @@ public class SteamManager : MonoBehaviour
             }
             catch (System.DllNotFoundException e)
             {
-                Debug.LogError("Steamworks DLL not found: " + e);
+                // Route initialization failures through the centralized helper
+                // so test cases can assert on the emitted error message.
+                LoggingHelper.LogError("Steamworks DLL not found: " + e);
             }
             // Pre-load the leaderboard so score submissions succeed
             FindOrCreateLeaderboard(leaderboardId, null);

--- a/Assets/Tests/EditMode/SteamManagerTests.cs
+++ b/Assets/Tests/EditMode/SteamManagerTests.cs
@@ -1,3 +1,11 @@
+// SteamManagerTests.cs
+// -----------------------------------------------------------------------------
+// Validates the behavior of SteamManager without requiring a live connection to
+// the Steam client. Leaderboard interactions, localization helpers, and startup
+// error handling are all exercised to ensure consistent behavior across builds.
+// Run via the Unity Test Runner in edit mode.
+// -----------------------------------------------------------------------------
+
 using NUnit.Framework;
 using UnityEngine;
 #if UNITY_STANDALONE
@@ -5,9 +13,9 @@ using Steamworks;
 #endif
 
 /// <summary>
-/// Tests for SteamManager verifying score submission and retrieval logic
-/// without relying on the real Steamworks API. Methods are overridden so
-/// calls can be inspected in isolation.
+/// Tests for SteamManager verifying score submission, leaderboard retrieval,
+/// achievement localization and initialization error logging. Methods are
+/// overridden where needed so interactions can be inspected in isolation.
 /// </summary>
 public class SteamManagerTests
 {
@@ -71,6 +79,24 @@ public class SteamManagerTests
         sm.DownloadTopScores(entries => called = true);
         Assert.IsTrue(sm.downloadRequested);
         Assert.IsTrue(called);
+        Object.DestroyImmediate(go);
+#else
+        Assert.Pass("Steamworks not available");
+#endif
+    }
+
+    /// <summary>
+    /// When the Steamworks native library is missing, the manager should route
+    /// the initialization failure through <see cref="LoggingHelper.LogError"/>.
+    /// </summary>
+    [Test]
+    public void Awake_LogsError_WhenSteamDllMissing()
+    {
+#if UNITY_STANDALONE
+        // Expect an error message about the missing DLL logged via LoggingHelper.
+        LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("Steamworks DLL not found"));
+        var go = new GameObject("sm");
+        go.AddComponent<SteamManager>();
         Object.DestroyImmediate(go);
 #else
         Assert.Pass("Steamworks not available");


### PR DESCRIPTION
## Summary
- route SteamManager initialization failures through LoggingHelper.LogError for centralized error handling
- add edit mode test confirming missing Steamworks DLL logs via LoggingHelper

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -logfile -` *(fails: command not found: Unity)*