### PR TITLE
Handle null starting power-ups

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using System;
 using System.Collections;
+using System.Collections.Generic; // Supports List<T> for filtering prefabs
 using TMPro; // TextMeshPro provides TMP_Text for UI labels
 
 // For a high-level overview of how GameManager collaborates with other systems, see docs/ArchitectureOverview.md.
@@ -101,6 +102,12 @@ using TMPro; // TextMeshPro provides TMP_Text for UI labels
 /// starting a run restores it to <c>1</c>. Centralizing time control here ensures
 /// all gameplay and physics-based systems halt uniformly when the game is
 /// paused and resume predictably.
+/// </remarks>
+/// <remarks>
+/// 2051 fix: <see cref="StartGame"/> now filters <see cref="startingPowerUps"/>
+/// for null entries before instantiation and logs a warning when invalid
+/// prefabs are encountered. This prevents runtime exceptions from
+/// misconfigured arrays and aids debugging during development.
 /// </remarks>
 /// </summary>
 public class GameManager : MonoBehaviour
@@ -654,12 +661,41 @@ public class GameManager : MonoBehaviour
         }
         else if (startingCount > 0 && startingPowerUps != null && startingPowerUps.Length > 0)
         {
-            // Spawn the configured power-up prefabs adjacent to the player.
-            Vector3 spawnPosition = playerObject.transform.position;
-            for (int i = 0; i < startingCount; i++)
+            // Filter out any null entries before selecting prefabs. Randomly
+            // choosing a null would cause Instantiate to throw, so we build a
+            // list of only valid prefabs first.
+            var validPrefabs = new List<GameObject>();
+            foreach (GameObject prefab in startingPowerUps)
             {
-                GameObject prefab = startingPowerUps[UnityEngine.Random.Range(0, startingPowerUps.Length)];
-                Instantiate(prefab, spawnPosition + Vector3.right * (i + 1), Quaternion.identity);
+                if (prefab != null)
+                {
+                    validPrefabs.Add(prefab);
+                }
+            }
+
+            // Warn developers when configuration errors are detected so they
+            // can fix missing references in the inspector.
+            if (validPrefabs.Count < startingPowerUps.Length)
+            {
+                LoggingHelper.LogWarning("StartGame: startingPowerUps contains null entries; skipping invalid prefabs.");
+            }
+
+            if (validPrefabs.Count > 0)
+            {
+                // Spawn the configured power-up prefabs adjacent to the player
+                // using only the validated list to avoid null reference errors.
+                Vector3 spawnPosition = playerObject.transform.position;
+                for (int i = 0; i < startingCount; i++)
+                {
+                    GameObject prefab = validPrefabs[UnityEngine.Random.Range(0, validPrefabs.Count)];
+                    Instantiate(prefab, spawnPosition + Vector3.right * (i + 1), Quaternion.identity);
+                }
+            }
+            else
+            {
+                // If every entry was invalid, nothing can be spawned. Logging a
+                // warning here provides clarity during debugging sessions.
+                LoggingHelper.LogWarning("StartGame: no valid starting power-up prefabs available; none spawned.");
             }
         }
 

--- a/Assets/Tests/EditMode/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameManagerTests.cs
@@ -245,6 +245,71 @@ public class GameManagerTests
         Object.DestroyImmediate(saveObj);
     }
 
+    /// <summary>
+    /// Ensures <see cref="GameManager.StartGame"/> gracefully skips null entries
+    /// in <see cref="GameManager.startingPowerUps"/>. A warning should be logged
+    /// and valid prefabs still spawn so misconfigured arrays do not crash the
+    /// game at runtime.
+    /// </summary>
+    [Test]
+    public void StartGame_NullStartingPowerUp_SkipsAndWarns()
+    {
+        // Enable verbose logging so the warning about null entries is emitted
+        // during the test but restore the original state afterward to avoid
+        // affecting other tests.
+        bool prevVerbose = LoggingHelper.VerboseEnabled;
+        LoggingHelper.VerboseEnabled = true;
+
+        // Create required singletons and grant one starting power-up upgrade.
+        var saveObj = new GameObject("save");
+        saveObj.AddComponent<SaveGameManager>();
+        var shopObj = new GameObject("shop");
+        var shop = shopObj.AddComponent<ShopManager>();
+        shop.availableUpgrades = new[]
+        {
+            new ShopManager.UpgradeData
+            {
+                type = UpgradeType.StartingPowerUp,
+                cost = 1,
+                effect = 1f
+            }
+        };
+        typeof(ShopManager).GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(shop, null);
+        var dictField = typeof(ShopManager).GetField("upgradeLevels", BindingFlags.NonPublic | BindingFlags.Instance);
+        var levels = (System.Collections.Generic.Dictionary<UpgradeType, int>)dictField.GetValue(shop);
+        levels[UpgradeType.StartingPowerUp] = 1;
+        dictField.SetValue(shop, levels);
+
+        // GameManager configured with one valid prefab and one null entry.
+        var gm = CreateGameManagerWithUI();
+        var go = gm.gameObject;
+        gm.startingPowerUps = new[] { new GameObject("PowerUp"), null };
+
+        // Assign player reference so StartGame proceeds normally.
+        var player = new GameObject("player");
+        typeof(GameManager).GetField("playerObject", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(gm, player);
+
+        // Expect a warning about the null entry and ensure no exception is thrown.
+        LogAssert.Expect(LogType.Warning, new Regex("startingPowerUps contains null"));
+        Assert.DoesNotThrow(() => gm.StartGame());
+
+        // Only the valid prefab should have spawned; the null entry is skipped.
+        Assert.IsNotNull(GameObject.Find("PowerUp(Clone)"));
+
+        LogAssert.NoUnexpectedReceived();
+
+        // Clean up spawned objects and singletons to keep the test isolated.
+        Object.DestroyImmediate(GameObject.Find("PowerUp(Clone)"));
+        Object.DestroyImmediate(go);
+        Object.DestroyImmediate(player);
+        Object.DestroyImmediate(shopObj);
+        Object.DestroyImmediate(saveObj);
+
+        // Restore the original verbose logging setting.
+        LoggingHelper.VerboseEnabled = prevVerbose;
+    }
+
     [Test]
     public void ActivateCoinBonus_MultipliesCoins()
     {


### PR DESCRIPTION
## Summary
- skip null entries in startingPowerUps and warn during StartGame
- test StartGame with a null prefab to ensure logging and safe spawning

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef3b1f8883218dcf3ef443f674f6