### PR TITLE
Handle invalid leaderboard URL as network error

### DIFF
--- a/Assets/Scripts/LeaderboardClient.cs
+++ b/Assets/Scripts/LeaderboardClient.cs
@@ -16,7 +16,9 @@ using UnityEngine.Networking;
 // meaningful error messages when network communication fails. In this revision
 // error handling has been expanded further with explicit error codes covering
 // network, HTTP, certificate and timeout issues so the UI can surface
-// localized explanations for each failure mode.
+// localized explanations for each failure mode. Missing or insecure service
+// URLs now trigger a NetworkError so callers can uniformly handle configuration
+// problems as connectivity failures.
 
 /// <summary>
 /// Client for a simple REST-based leaderboard service used when Steamworks
@@ -117,7 +119,9 @@ public class LeaderboardClient : MonoBehaviour
         // allow insecure plaintext traffic or null requests.
         if (!IsServiceUrlSecure())
         {
-            onComplete?.Invoke(false);
+            // Treat missing or insecure URLs as a network error so callers can
+            // display a consistent failure message to the player.
+            onComplete?.Invoke(false, ErrorCode.NetworkError);
             yield break;
         }
 

--- a/Assets/Tests/EditMode/LeaderboardClientTests.cs
+++ b/Assets/Tests/EditMode/LeaderboardClientTests.cs
@@ -196,6 +196,30 @@ public class LeaderboardClientTests
     }
 
     /// <summary>
+    /// UploadScore should surface a NetworkError when no valid HTTPS URL is
+    /// configured. This ensures misconfiguration is treated the same as other
+    /// connectivity issues so callers can present a consistent message.
+    /// </summary>
+    [Test]
+    public void UploadScore_InvalidUrlReportsNetworkError()
+    {
+        var go = new GameObject("lbInvalidUrl");
+        var client = go.AddComponent<LeaderboardClient>(); // Uses default empty serviceUrl
+
+        bool success = true;
+        LeaderboardClient.ErrorCode err = LeaderboardClient.ErrorCode.None;
+
+        var routine = client.UploadScore(10, (ok, code) => { success = ok; err = code; });
+        while (routine.MoveNext()) { }
+
+        Assert.IsFalse(success, "Upload should fail when serviceUrl is invalid");
+        Assert.AreEqual(LeaderboardClient.ErrorCode.NetworkError, err,
+            "Invalid URL should report a NetworkError");
+
+        Object.DestroyImmediate(go);
+    }
+
+    /// <summary>
     /// Upload operations should retry on failure and apply the configured
     /// timeout to each attempt.
     /// </summary>


### PR DESCRIPTION
## Summary
- return `NetworkError` when the leaderboard service URL is missing or insecure
- add regression test to ensure invalid URLs surface `NetworkError`

## Testing
- `Unity -batchmode -projectPath . -runTests -testPlatform editmode -testResults Results.xml -logFile test.log -quit` *(fails: command not found)*
- `apt-get install -y unity-editor` *(fails: package not found)*
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2357c1c8321a1a4048b31cc2364