### PR TITLE
Buffer daily challenge saves

### DIFF
--- a/Assets/Scripts/DailyChallengeManager.cs
+++ b/Assets/Scripts/DailyChallengeManager.cs
@@ -1,6 +1,15 @@
 using UnityEngine;
 using System;
 
+//------------------------------------------------------------------------------
+// Updated for buffered state persistence. The previous implementation wrote
+// challenge progress to PlayerPrefs every frame, which caused unnecessary disk
+// I/O. Progress is now marked dirty when it changes and flushed only after the
+// value increases by a threshold or a fixed time interval has elapsed. The
+// final state is also saved when the application pauses or quits to avoid data
+// loss.
+//------------------------------------------------------------------------------
+
 /// <summary>
 /// Generates and tracks a single daily challenge. The challenge persists in
 /// PlayerPrefs with an expiry timestamp so players receive a new objective
@@ -41,9 +50,21 @@ public class DailyChallengeManager : MonoBehaviour
     private const int RewardCoins = 25;                    // coins awarded on completion
     private const string AchComplete = "ACH_DAILY_COMPLETE";
 
+    // Minimum change required before auto-saving to reduce write frequency.
+    private static readonly int ProgressSaveThreshold = 5;
+    // Seconds between automatic saves when progress is changing slowly.
+    private static readonly float SaveInterval = 1f;
+
     public static DailyChallengeManager Instance { get; private set; }
 
     private ChallengeState state;
+
+    // Tracks unsaved changes so persistence can be deferred until necessary.
+    private bool isDirty;
+    // Timestamp of the last flush to PlayerPrefs.
+    private float lastSaveTime;
+    // Progress value stored during the last save for delta comparisons.
+    private int lastSavedProgress;
 
     /// <summary>
     /// Initializes the singleton instance and loads or creates the current
@@ -64,8 +85,9 @@ public class DailyChallengeManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Checks for completion each frame by comparing GameManager metrics
-    /// against the active challenge.
+    /// Updates challenge progress from <see cref="GameManager"/> statistics.
+    /// Progress changes are marked dirty and persisted in batches to avoid
+    /// expensive per-frame disk writes.
     /// </summary>
     void Update()
     {
@@ -83,18 +105,28 @@ public class DailyChallengeManager : MonoBehaviour
             case ChallengeType.Distance:
                 if (GameManager.Instance != null)
                 {
-                    state.progress = Mathf.FloorToInt(GameManager.Instance.GetDistance());
-                    SaveState();
+                    int newProgress = Mathf.FloorToInt(GameManager.Instance.GetDistance());
+                    if (newProgress != state.progress)
+                    {
+                        state.progress = newProgress;
+                        isDirty = true; // mark for deferred save
+                    }
                 }
                 break;
             case ChallengeType.Coins:
                 if (GameManager.Instance != null)
                 {
-                    state.progress = GameManager.Instance.GetCoins();
-                    SaveState();
+                    int newProgress = GameManager.Instance.GetCoins();
+                    if (newProgress != state.progress)
+                    {
+                        state.progress = newProgress;
+                        isDirty = true; // mark for deferred save
+                    }
                 }
                 break;
         }
+
+        MaybeFlushState();
 
         if (state.progress >= state.target)
         {
@@ -103,7 +135,8 @@ public class DailyChallengeManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Records usage of a power-up so power-up challenges can progress.
+    /// Records usage of a power-up so power-up challenges can progress. The
+    /// update is buffered and only persisted once thresholds or timers are met.
     /// </summary>
     public void RecordPowerUpUse(PowerUpType type)
     {
@@ -112,13 +145,14 @@ public class DailyChallengeManager : MonoBehaviour
         if (state.type == ChallengeType.PowerUpUse && state.powerUp == type)
         {
             state.progress++;
+            isDirty = true; // track unsaved progress
             if (state.progress >= state.target)
             {
                 CompleteChallenge();
             }
             else
             {
-                SaveState();
+                MaybeFlushState();
             }
         }
     }
@@ -161,6 +195,13 @@ public class DailyChallengeManager : MonoBehaviour
             {
                 GenerateChallenge();
             }
+            else
+            {
+                // Initialize tracking fields for existing saved progress.
+                lastSavedProgress = state.progress;
+                lastSaveTime = Time.time;
+                isDirty = false;
+            }
         }
         else
         {
@@ -187,13 +228,35 @@ public class DailyChallengeManager : MonoBehaviour
         SaveState();
     }
 
-    // Writes the current state to PlayerPrefs for persistence across sessions.
+    // Saves progress only when enough change has accumulated or the interval elapsed.
+    private void MaybeFlushState()
+    {
+        if (!isDirty || state == null)
+            return; // nothing to persist
+
+        // Flush when progress jumps significantly or after the timeout.
+        if (Mathf.Abs(state.progress - lastSavedProgress) >= ProgressSaveThreshold ||
+            Time.time - lastSaveTime >= SaveInterval)
+        {
+            SaveState();
+        }
+    }
+
+    // Writes the current state to PlayerPrefs and clears the dirty flag so
+    // future saves can be throttled.
     private void SaveState()
     {
-        if (state == null) return;
+        if (state == null)
+            return;
+
         string json = JsonUtility.ToJson(state);
         PlayerPrefs.SetString(PrefKey, json);
         PlayerPrefs.Save();
+
+        // Track save metadata so future writes can be throttled.
+        lastSavedProgress = state.progress;
+        lastSaveTime = Time.time;
+        isDirty = false;
     }
 
     // Grants the reward and flags the challenge as complete.
@@ -212,18 +275,21 @@ public class DailyChallengeManager : MonoBehaviour
     }
 
     // Persist the challenge whenever the application quits so progress is not
-    // lost on shutdown.
+    // lost on shutdown. Only writes when there are unsaved changes.
     void OnApplicationQuit()
     {
-        SaveState();
+        // Persist unsaved progress when shutting down.
+        if (isDirty)
+            SaveState();
     }
 
-    // Mobile platforms may pause the app without quitting. Save progress when
-    // entering the background.
+    // Mobile platforms may pause the app without quitting. Any pending progress
+    // is flushed when entering the background.
     void OnApplicationPause(bool paused)
     {
-        if (paused)
+        if (paused && isDirty)
         {
+            // Entering background: ensure current progress is stored.
             SaveState();
         }
     }

--- a/Assets/Tests/EditMode/DailyChallengeManagerTests.cs
+++ b/Assets/Tests/EditMode/DailyChallengeManagerTests.cs
@@ -156,12 +156,81 @@ public class DailyChallengeManagerTests
     }
 
     /// <summary>
-    /// Progress for distance and coin challenges should be persisted every
-    /// frame so exiting the game does not reset progress.
+    /// Verifies progress is buffered: values below the threshold are not saved
+    /// immediately, but once the threshold is met the state is persisted for
+    /// both distance and coin challenges.
     /// </summary>
     [Test]
-    public void Update_SavesProgressForDistanceAndCoins()
+    public void Update_OnlySavesAfterThreshold()
     {
+        int threshold = (int)typeof(DailyChallengeManager)
+            .GetField("ProgressSaveThreshold", BindingFlags.NonPublic | BindingFlags.Static)
+            .GetValue(null);
+
+        var gmObj = new GameObject("gm");
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.StartGame();
+
+        // --- Distance challenge threshold test ---
+        var state = new PrivateChallengeState
+        {
+            type = DailyChallengeManager.ChallengeType.Distance,
+            target = threshold * 2,
+            progress = 0,
+            powerUp = DailyChallengeManager.PowerUpType.Magnet,
+            expires = System.DateTime.UtcNow.AddDays(1).Ticks,
+            completed = false
+        };
+        PlayerPrefs.SetString("DailyChallengeData", JsonUtility.ToJson(state));
+
+        var dcObj = new GameObject("dc");
+        var dc = dcObj.AddComponent<DailyChallengeManager>();
+
+        typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, (float)(threshold - 1));
+        dc.Update();
+        var loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
+        Assert.AreEqual(0, loaded.progress, "Progress below threshold should not persist");
+
+        typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, (float)threshold);
+        dc.Update();
+        loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
+        Assert.AreEqual(threshold, loaded.progress, "Progress should persist once threshold reached");
+
+        Object.DestroyImmediate(dcObj);
+
+        // --- Coin challenge threshold test ---
+        state.type = DailyChallengeManager.ChallengeType.Coins;
+        state.progress = 0;
+        PlayerPrefs.SetString("DailyChallengeData", JsonUtility.ToJson(state));
+
+        var dcObj2 = new GameObject("dc2");
+        var dc2 = dcObj2.AddComponent<DailyChallengeManager>();
+
+        typeof(GameManager).GetField("coins", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, threshold - 1);
+        dc2.Update();
+        loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
+        Assert.AreEqual(0, loaded.progress, "Coin progress below threshold should not persist");
+
+        typeof(GameManager).GetField("coins", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, threshold);
+        dc2.Update();
+        loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
+        Assert.AreEqual(threshold, loaded.progress, "Coin progress should persist once threshold reached");
+
+        Object.DestroyImmediate(dcObj2);
+        Object.DestroyImmediate(gmObj);
+    }
+
+    /// <summary>
+    /// Even small progress changes are eventually flushed when the save interval
+    /// elapses to prevent data loss.
+    /// </summary>
+    [Test]
+    public void Update_SavesAfterInterval()
+    {
+        float interval = (float)typeof(DailyChallengeManager)
+            .GetField("SaveInterval", BindingFlags.NonPublic | BindingFlags.Static)
+            .GetValue(null);
+
         var state = new PrivateChallengeState
         {
             type = DailyChallengeManager.ChallengeType.Distance,
@@ -176,23 +245,23 @@ public class DailyChallengeManagerTests
         var gmObj = new GameObject("gm");
         var gm = gmObj.AddComponent<GameManager>();
         gm.StartGame();
-        typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, 4f);
 
         var dcObj = new GameObject("dc");
         var dc = dcObj.AddComponent<DailyChallengeManager>();
 
+        // Progress by a small amount; no save should occur yet.
+        typeof(GameManager).GetField("distance", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, 1f);
         dc.Update();
         var loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
-        Assert.AreEqual(4, loaded.progress, "Distance progress should be saved");
+        Assert.AreEqual(0, loaded.progress, "Initial small progress should be buffered");
 
-        loaded.type = DailyChallengeManager.ChallengeType.Coins;
-        loaded.progress = 0;
-        PlayerPrefs.SetString("DailyChallengeData", JsonUtility.ToJson(loaded));
-        typeof(GameManager).GetField("coins", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(gm, 3);
+        // Force the timer to appear elapsed then update again so progress saves.
+        typeof(DailyChallengeManager)
+            .GetField("lastSaveTime", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(dc, Time.time - interval - 0.1f);
         dc.Update();
-
         loaded = JsonUtility.FromJson<PrivateChallengeState>(PlayerPrefs.GetString("DailyChallengeData"));
-        Assert.AreEqual(3, loaded.progress, "Coin progress should be saved");
+        Assert.AreEqual(1, loaded.progress, "Progress should save after interval passes");
 
         Object.DestroyImmediate(dcObj);
         Object.DestroyImmediate(gmObj);


### PR DESCRIPTION
## Summary
- buffer daily challenge persistence to avoid per-frame PlayerPrefs writes
- add threshold- and interval-based saving plus dirty state tracking
- expand unit tests to cover new buffering behaviour

## Testing
- `dotnet test` *(fails: command not found)*